### PR TITLE
Fix error in parsing incorrectly declared attributes.

### DIFF
--- a/src/HtmlAgilityPack/HtmlDocument.cs
+++ b/src/HtmlAgilityPack/HtmlDocument.cs
@@ -1280,7 +1280,18 @@ namespace HtmlAgilityPack
 							PushNodeStart(HtmlNodeType.Text, _index);
 							continue;
 						}
-						_state = ParseState.BetweenAttributes;
+
+                        // we may end up in this state if attributes are incorrectly seperated
+                        // by a /-character. If so, start parsing attribute-name immediately.
+                        if (!IsWhiteSpace(_c))
+                        {
+                            PushAttributeNameStart(_index - 1);
+                            _state = ParseState.AttributeName;
+                        }
+                        else
+                        {
+                            _state = ParseState.BetweenAttributes;
+                        }
 						break;
 
 					case ParseState.AttributeName:


### PR DESCRIPTION
When parsing incorrectly declared attributes, HtmlAgilityPack currently omits one character from the attribute-name.

Consider the following example:

````html
<html>
   <body>
    <img src='http://boo'/onerror='moo'>
  </body>
</html>
````

When parsed this will result in two attributes for the `img` node:

* `src`
* `nerror` (note missing leading `o`)

Expected outcome should be:

* `src`
* `onerror`

This patch fixes the output to match what you would expect (and how browser handle similarly formatted data). This closes https://github.com/zzzprojects/html-agility-pack/issues/16.

Note: In lack of a test-suite for this project, I cannot reliably tell if I've broken other expected behaviour in the process.

Are there any recommended test-procedures I should follow, or is this good as is?