### PR TITLE
fix assembly name for NETSTANDARD1_3 project

### DIFF
--- a/src/HtmlAgilityPack.NETStandard1_3/HtmlAgilityPack.NETStandard1_3.csproj
+++ b/src/HtmlAgilityPack.NETStandard1_3/HtmlAgilityPack.NETStandard1_3.csproj
@@ -11,7 +11,7 @@
     <TargetFramework>netstandard1.3</TargetFramework>
     <PostBuildEvent>del /f /q C:\Users\Jonathan\Desktop\Z\zzzproject\HtmlAgilityPack\Solutions\..\Nuget\lib\NetStandard1_3\*
 copy "Html*.*" C:\Users\Jonathan\Desktop\Z\zzzproject\HtmlAgilityPack\Solutions\..\Nuget\lib\NetStandard1_3\*</PostBuildEvent>
-    <PackageId>HtmlAgilityPack</PackageId>
+    <AssemblyName>HtmlAgilityPack</AssemblyName>
     <Version>1.5.0</Version>
     <Authors>ZZZ Projects Inc.</Authors>
     <Company>ZZZ Projects Inc.</Company>


### PR DESCRIPTION
The assembly name for the NETSTANDARD1_3 project was left as the default name, which produced an assembly named HtmlAgilityPack.NETStandard1_3.dll, instead of HtmlAgilityPack.dll