### PR TITLE
fix for issue #27

### DIFF
--- a/src/HtmlAgilityPack.Shared/HtmlEntity.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlEntity.cs
@@ -643,8 +643,7 @@ namespace HtmlAgilityPack
                                     {
                                         // named entity?
                                         int code;
-                                        object o = _entityValue[entity.ToString()];
-                                        if (o == null)
+                                        if (!_entityValue.TryGetValue(entity.ToString(), out code))
                                         {
                                             // nope
                                             sb.Append("&" + entity + ";");
@@ -652,7 +651,6 @@ namespace HtmlAgilityPack
                                         else
                                         {
                                             // we found one
-                                            code = (int) o;
                                             sb.Append(Convert.ToChar(code));
                                         }
                                     }

--- a/src/HtmlAgilityPack/HtmlEntity.cs
+++ b/src/HtmlAgilityPack/HtmlEntity.cs
@@ -643,8 +643,7 @@ namespace HtmlAgilityPack
                                     {
                                         // named entity?
                                         int code;
-                                        object o = _entityValue[entity.ToString()];
-                                        if (o == null)
+                                        if (!_entityValue.TryGetValue(entity.ToString(), out code))
                                         {
                                             // nope
                                             sb.Append("&" + entity + ";");
@@ -652,7 +651,6 @@ namespace HtmlAgilityPack
                                         else
                                         {
                                             // we found one
-                                            code = (int) o;
                                             sb.Append(Convert.ToChar(code));
                                         }
                                     }


### PR DESCRIPTION
getting value from dictionary by not existing key results in KeyNotFoundException. It is safer to use TryGetValue. As, there is no null values in dictionary, checking out value for null is not need.