### PR TITLE
Obsolete crc32 and use a internal copy

### DIFF
--- a/src/HAPCompact/HAPCompact.csproj
+++ b/src/HAPCompact/HAPCompact.csproj
@@ -57,6 +57,9 @@
     <Compile Include="..\HtmlAgilityPack\crc32.cs">
       <Link>crc32.cs</Link>
     </Compile>
+    <Compile Include="..\HtmlAgilityPack\InternalCrc32.cs">
+      <Link>InternalCrc32.cs</Link>
+    </Compile>
     <Compile Include="..\HtmlAgilityPack\EncodingFoundException.cs">
       <Link>EncodingFoundException.cs</Link>
     </Compile>

--- a/src/HAPLight/HAPLight.5.0.csproj
+++ b/src/HAPLight/HAPLight.5.0.csproj
@@ -64,6 +64,9 @@
     <Compile Include="..\HtmlAgilityPack\crc32.cs">
       <Link>crc32.cs</Link>
     </Compile>
+    <Compile Include="..\HtmlAgilityPack\InternalCrc32.cs">
+      <Link>InternalCrc32.cs</Link>
+    </Compile>
     <Compile Include="..\HtmlAgilityPack\EncodingFoundException.cs">
       <Link>EncodingFoundException.cs</Link>
     </Compile>

--- a/src/HAPLight/HAPLight.csproj
+++ b/src/HAPLight/HAPLight.csproj
@@ -64,6 +64,9 @@
     <Compile Include="..\HtmlAgilityPack\crc32.cs">
       <Link>crc32.cs</Link>
     </Compile>
+    <Compile Include="..\HtmlAgilityPack\InternalCrc32.cs">
+      <Link>InternalCrc32.cs</Link>
+    </Compile>
     <Compile Include="..\HtmlAgilityPack\EncodingFoundException.cs">
       <Link>EncodingFoundException.cs</Link>
     </Compile>

--- a/src/HAPPhone.7.1/HAPPhone.7.1.csproj
+++ b/src/HAPPhone.7.1/HAPPhone.7.1.csproj
@@ -57,6 +57,9 @@
     <Compile Include="..\HtmlAgilityPack\crc32.cs">
       <Link>crc32.cs</Link>
     </Compile>
+    <Compile Include="..\HtmlAgilityPack\InternalCrc32.cs">
+      <Link>InternalCrc32.cs</Link>
+    </Compile>
     <Compile Include="..\HtmlAgilityPack\EncodingFoundException.cs">
       <Link>EncodingFoundException.cs</Link>
     </Compile>

--- a/src/HAPPhone/HAPPhone.csproj
+++ b/src/HAPPhone/HAPPhone.csproj
@@ -57,6 +57,9 @@
     </Compile>
     <Compile Include="..\HtmlAgilityPack\crc32.cs">
       <Link>crc32.cs</Link>
+    </Compile>	
+    <Compile Include="..\HtmlAgilityPack\InternalCrc32.cs">
+      <Link>InternalCrc32.cs</Link>
     </Compile>
     <Compile Include="..\HtmlAgilityPack\EncodingFoundException.cs">
       <Link>EncodingFoundException.cs</Link>

--- a/src/HAPPortable/HAPPortable.csproj
+++ b/src/HAPPortable/HAPPortable.csproj
@@ -39,6 +39,9 @@
     <Compile Include="..\HtmlAgilityPack\crc32.cs">
       <Link>crc32.cs</Link>
     </Compile>
+    <Compile Include="..\HtmlAgilityPack\InternalCrc32.cs">
+      <Link>InternalCrc32.cs</Link>
+    </Compile>
     <Compile Include="..\HtmlAgilityPack\EncodingFoundException.cs">
       <Link>EncodingFoundException.cs</Link>
     </Compile>

--- a/src/HtmlAgilityPack.Metro/HtmlAgilityPack.Metro.csproj
+++ b/src/HtmlAgilityPack.Metro/HtmlAgilityPack.Metro.csproj
@@ -49,6 +49,9 @@
     <Compile Include="..\HtmlAgilityPack\crc32.cs">
       <Link>crc32.cs</Link>
     </Compile>
+    <Compile Include="..\HtmlAgilityPack\InternalCrc32.cs">
+      <Link>InternalCrc32.cs</Link>
+    </Compile>
     <Compile Include="..\HtmlAgilityPack\EncodingFoundException.cs">
       <Link>EncodingFoundException.cs</Link>
     </Compile>

--- a/src/HtmlAgilityPack.Shared/HtmlAgilityPack.Shared.projitems
+++ b/src/HtmlAgilityPack.Shared/HtmlAgilityPack.Shared.projitems
@@ -17,6 +17,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)crc32.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)InternalCrc32.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)EncodingFoundException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HtmlAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HtmlAttributeCollection.cs" />

--- a/src/HtmlAgilityPack/HtmlAgilityPack.csproj
+++ b/src/HtmlAgilityPack/HtmlAgilityPack.csproj
@@ -65,6 +65,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="InternalCrc32.cs" />
     <Compile Include="EncodingFoundException.cs" />
     <Compile Include="HtmlAttributeCollection.cs" />
     <Compile Include="HtmlCommentNode.cs" />

--- a/src/HtmlAgilityPack/HtmlDocument.cs
+++ b/src/HtmlAgilityPack/HtmlDocument.cs
@@ -27,7 +27,7 @@ namespace HtmlAgilityPack
         private static int _maxDepthLevel = int.MaxValue;
 
         private int _c;
-        private Crc32 _crc32;
+        private InternalCrc32 _crc32;
         private HtmlAttribute _currentattribute;
         private HtmlNode _currentnode;
         private Encoding _declaredencoding;
@@ -1151,7 +1151,7 @@ namespace HtmlAgilityPack
             int lastquote = 0;
             if (OptionComputeChecksum)
             {
-                _crc32 = new Crc32();
+                _crc32 = new InternalCrc32();
             }
 
             Lastnodes = new Dictionary<string, HtmlNode>();

--- a/src/HtmlAgilityPack/InternalCrc32.cs
+++ b/src/HtmlAgilityPack/InternalCrc32.cs
@@ -4,8 +4,7 @@ namespace HtmlAgilityPack
     /// <summary>
     /// A utility class to compute CRC32.
     /// </summary>
-    [System.Obsolete("This type should not be used; it is intended for internal use in HTML Agility Pack.")]
-    public class Crc32
+    internal sealed class InternalCrc32
     {
         #region Fields
 


### PR DESCRIPTION
The type ``Crc32`` is currently public, but it should not be.
The reasons are that this is a type that is only used as a "helper", and that this library is not dealing with hashing funtions per-se and hence should not publicly expose any.

Since we cannot delete (or internalise) a public type without introducing a breaking change, I marked the type as ``Obsolete`` to discourage its use by consumers of this library, and created an ``internal sealed class InternalCrc32`` as internal replacement.

The original ``Crc32`` can go out of service when the next breaking changes are introduced. 