### PR TITLE
fixes wrong path detection when url ends with /

### DIFF
--- a/src/HtmlAgilityPack.Shared/HtmlWeb.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlWeb.cs
@@ -3,7 +3,7 @@
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE
 // More projects: http://www.zzzprojects.com/
-// Copyright © ZZZ Projects Inc. 2014 - 2017. All rights reserved.
+// Copyright Â© ZZZ Projects Inc. 2014 - 2017. All rights reserved.
 
 #if !METRO
 #region
@@ -1140,7 +1140,7 @@ namespace HtmlAgilityPack
             }
             else
             {
-                cachePath = Path.Combine(_cachePath, (uri.Host + uri.AbsolutePath).Replace('/', '\\'));
+                cachePath = Path.Combine(_cachePath, (uri.Host + uri.AbsolutePath.TrimEnd(Path.AltDirectorySeparatorChar)).Replace('/', '\\'));
             }
             return cachePath;
         }
@@ -1711,7 +1711,7 @@ namespace HtmlAgilityPack
                         }
                         catch
                         {
-                            // That’s fine, the content type was unknown so probably not HTML
+                            // ThatÂ’s fine, the content type was unknown so probably not HTML
                             // Perhaps trying to figure if the content contains some HTML before would be a better idea.
                         }
                     }
@@ -1914,7 +1914,7 @@ namespace HtmlAgilityPack
                             }
                             catch
                             {
-                                // That’s fine, the content type was unknown so probably not HTML
+                                // ThatÂ’s fine, the content type was unknown so probably not HTML
                                 // Perhaps trying to figure if the content contains some HTML before would be a better idea.
                             }
                         }


### PR DESCRIPTION
Trailing `/` causes `Path.GetDirectoryName` to detect last path as directory instead of file.


Following code demonstrates the issue.

```csharp
void Main()
{
	const string url = "https://docs.microsoft.com/en-us/aspnet/mvc/videos/";

	/*
	PATH
	C:\temp\cache\docs.microsoft.com\en-us\aspnet\mvc\videos 

	FILENAME

	*/

	Parse(url);

	/*
	PATH
	C:\temp\cache\docs.microsoft.com\en-us\aspnet\mvc 

	FILENAME
	videos
	*/

	Parse(url.TrimEnd(Path.AltDirectorySeparatorChar));
}

private void Parse(string url)
{
	const string defaultExtension = ".html";
	const string cachePath = @"C:\temp\cache\";
	
	var uri = new Uri(url);
	bool isAbsolutePathRoot = uri.AbsolutePath.Equals(Path.AltDirectorySeparatorChar.ToString());
	var suffix = (uri.Host + uri.AbsolutePath).Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
	string path = Path.Combine(cachePath, isAbsolutePathRoot
														 ? defaultExtension
														 : suffix);
	Path.GetDirectoryName(path).Dump("PATH");
	Path.GetFileName(path).Dump("FILENAME");
}
```