### PR TITLE
Resolve ordering problem with HtmlNode.RemoveChild(oldchild,keepGrandChildren)

### DIFF
--- a/src/HtmlAgilityPack/HtmlNode.cs
+++ b/src/HtmlAgilityPack/HtmlNode.cs
@@ -1378,7 +1378,7 @@ namespace HtmlAgilityPack
 				// reroute grand children to ourselves
 				foreach (HtmlNode grandchild in oldChild._childnodes)
 				{
-					InsertAfter(grandchild, prev);
+					prev = InsertAfter(grandchild, prev);
 				}
 			}
 			RemoveChild(oldChild);


### PR DESCRIPTION
This PR fixes a bug with the `HtmlNode.RemoveChild(oldchild,keepGrandChildren)` method.

When the keepGrandChildren flag is true the ordering of the children elements change.

This bug was well documented in the codeplex repo, but a fix was never merged for it. 

This fix is copied from [mikebridge's](https://htmlagilitypack.codeplex.com/workitem/9113#PostedByLink0) response to the issue in 2007.

Codeplex Issues: 
https://htmlagilitypack.codeplex.com/workitem/9113
https://htmlagilitypack.codeplex.com/workitem/28756
https://htmlagilitypack.codeplex.com/workitem/43552