### PR TITLE
Minor performance and GC traffic optimizations

### DIFF
--- a/src/HtmlAgilityPack.Shared/HtmlAttribute.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlAttribute.cs
@@ -26,6 +26,7 @@ namespace HtmlAgilityPack
         private int _line;
         internal int _lineposition;
         internal string _name;
+        internal string _optimizedName;
         internal int _namelength;
         internal int _namestartindex;
         internal HtmlDocument _ownerdocument; // attribute can exists without a node
@@ -77,7 +78,12 @@ namespace HtmlAgilityPack
                 {
                     _name = _ownerdocument.Text.Substring(_namestartindex, _namelength);
                 }
-                return _name.ToLower();
+
+                if (_optimizedName == null)
+                {
+                    _optimizedName = OwnerDocument.OptionLowerCaseWhenParsing ? _name.ToLowerInvariant() : _name;
+                }
+                return _optimizedName;
             }
             set
             {
@@ -86,6 +92,7 @@ namespace HtmlAgilityPack
                     throw new ArgumentNullException("value");
                 }
                 _name = value;
+                _optimizedName = null;
                 if (_ownernode != null)
                 {
                     _ownernode.SetChanged();

--- a/src/HtmlAgilityPack.Shared/HtmlAttributeCollection.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlAttributeCollection.cs
@@ -254,7 +254,7 @@ namespace HtmlAgilityPack
         {
             for (int i = 0; i < items.Count; i++)
             {
-                if (items[i].Name.Equals(name.ToLower()))
+                if (String.Equals(items[i].Name, name, StringComparison.OrdinalIgnoreCase))
                     return true;
             }
             return false;
@@ -300,11 +300,10 @@ namespace HtmlAgilityPack
                 throw new ArgumentNullException("name");
             }
 
-            string lname = name.ToLower();
             for (int i = 0; i < items.Count; i++)
             {
                 HtmlAttribute att = items[i];
-                if (att.Name == lname)
+                if (String.Equals(att.Name, name, StringComparison.OrdinalIgnoreCase))
                 {
                     RemoveAt(i);
                 }
@@ -333,10 +332,9 @@ namespace HtmlAgilityPack
         /// <returns></returns>
         public IEnumerable<HtmlAttribute> AttributesWithName(string attributeName)
         {
-            attributeName = attributeName.ToLower();
             for (int i = 0; i < items.Count; i++)
             {
-                if (items[i].Name.Equals(attributeName))
+                if (String.Equals(items[i].Name, attributeName, StringComparison.OrdinalIgnoreCase))
                     yield return items[i];
             }
         }
@@ -382,10 +380,10 @@ namespace HtmlAgilityPack
             {
                 throw new ArgumentNullException("name");
             }
-            string lname = name.ToLower();
+
             for (int i = 0; i < items.Count; i++)
             {
-                if ((items[i]).Name == lname)
+                if (String.Equals((items[i]).Name, name, StringComparison.OrdinalIgnoreCase))
                     return i;
             }
             return -1;

--- a/src/HtmlAgilityPack.Shared/HtmlDocument.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlDocument.cs
@@ -156,6 +156,11 @@ namespace HtmlAgilityPack
         /// </summary>
         public bool OptionWriteEmptyNodes;
 
+        /// <summary>
+        /// Defines if node and attribute names should be converted to lowercase.
+        /// </summary>
+        public bool OptionLowerCaseWhenParsing = true;
+
         #endregion
 
         #region Static Members
@@ -167,6 +172,13 @@ namespace HtmlAgilityPack
         internal static readonly string HtmlExceptionClassDoesNotExist = "Class name doesn't exist";
 
         internal static readonly string HtmlExceptionClassExists = "Class name already exists";
+
+        internal static readonly KeyValuePair<string, string[]>[] HtmlResetters = {
+            new KeyValuePair<string, string[]>("li", new[] {"ul", "ol"}),
+            new KeyValuePair<string, string[]>("tr", new[] {"table"}),
+            new KeyValuePair<string, string[]>("th", new[] {"tr", "table"}),
+            new KeyValuePair<string, string[]>("td", new[] {"tr", "table"}),
+        };
 
         #endregion
 
@@ -569,7 +581,8 @@ namespace HtmlAgilityPack
             {
                 throw new Exception(HtmlExceptionUseIdAttributeFalse);
             }
-            return Nodesid.ContainsKey(id) ? Nodesid[id] : null;
+
+            return Utilities.GetDictionaryValueOrDefault(Nodesid, id);
         }
 
         /// <summary>
@@ -879,7 +892,7 @@ namespace HtmlAgilityPack
                 return;
 
             bool error = false;
-            HtmlNode prev = Utilities.GetDictionaryValueOrNull(Lastnodes, _currentnode.Name);
+            HtmlNode prev = Utilities.GetDictionaryValueOrDefault(Lastnodes, _currentnode.Name);
 
             // find last node of this kind
             if (prev == null)
@@ -928,7 +941,9 @@ namespace HtmlAgilityPack
                         // this is a hack: add it as a text node
                         HtmlNode closenode = CreateNode(HtmlNodeType.Text, _currentnode._outerstartindex);
                         closenode._outerlength = _currentnode._outerlength;
-                        ((HtmlTextNode) closenode).Text = ((HtmlTextNode) closenode).Text.ToLower();
+                        if (closenode.OwnerDocument.OptionLowerCaseWhenParsing) {
+                            ((HtmlTextNode) closenode).Text = ((HtmlTextNode) closenode).Text.ToLowerInvariant();
+                        }
                         if (_lastparentnode != null)
                         {
                             _lastparentnode.AppendChild(closenode);
@@ -1016,7 +1031,7 @@ namespace HtmlAgilityPack
 
         private HtmlNode FindResetterNode(HtmlNode node, string name)
         {
-            HtmlNode resetter = Utilities.GetDictionaryValueOrNull(Lastnodes, name);
+            HtmlNode resetter = Utilities.GetDictionaryValueOrDefault(Lastnodes, name);
             if (resetter == null)
                 return null;
 
@@ -1049,7 +1064,7 @@ namespace HtmlAgilityPack
             if (resetters == null)
                 return;
 
-            HtmlNode prev = Utilities.GetDictionaryValueOrNull(Lastnodes, _currentnode.Name);
+            HtmlNode prev = Utilities.GetDictionaryValueOrDefault(Lastnodes, _currentnode.Name);
             // if we find a previous unclosed same name node, without a resetter node between, we must close it
             if (prev == null || (Lastnodes[name].Closed)) return;
             // try to find a resetter node, if found, we do nothing
@@ -1077,21 +1092,14 @@ namespace HtmlAgilityPack
 
         private string[] GetResetters(string name)
         {
-            switch (name)
+            for (int i = 0; i < HtmlResetters.Length; i++) 
             {
-                case "li":
-                    return new string[] {"ul", "ol"};
-
-                case "tr":
-                    return new string[] {"table"};
-
-                case "th":
-                case "td":
-                    return new string[] {"tr", "table"};
-
-                default:
-                    return null;
+                KeyValuePair<string, string[]> resetter = HtmlResetters[i];
+                if (resetter.Key == name)
+                    return resetter.Value;
             }
+
+                    return null;
         }
 
         private void IncrementPosition()
@@ -1661,21 +1669,21 @@ namespace HtmlAgilityPack
             bool isImplicitEnd = false;
 
             var parent = _lastparentnode.Name;
-            var nodeName = Text.Substring(_currentnode._namestartindex, _index - _currentnode._namestartindex - 1);
+            int nodeNameLength = _index - _currentnode._namestartindex - 1;
 
             switch (parent)
             {
                 case "a":
-                    isImplicitEnd = nodeName == "a";
+                    isImplicitEnd = Utilities.StringSubstringEquals(Text, "a", _currentnode._namestartindex, nodeNameLength, StringComparison.Ordinal);
                     break;
                 case "dd":
-                    isImplicitEnd = nodeName == "dt" || nodeName == "dd";
-                    break;
                 case "dt":
-                    isImplicitEnd = nodeName == "dt" || nodeName == "dd";
+                    isImplicitEnd =
+                        Utilities.StringSubstringEquals(Text, "dt", _currentnode._namestartindex, nodeNameLength, StringComparison.Ordinal) ||
+                        Utilities.StringSubstringEquals(Text, "dd", _currentnode._namestartindex, nodeNameLength, StringComparison.Ordinal);
                     break;
                 case "p":
-                    isImplicitEnd = nodeName == "p";
+                    isImplicitEnd = Utilities.StringSubstringEquals(Text, "p", _currentnode._namestartindex, nodeNameLength, StringComparison.Ordinal);;
                     break;
             }
 
@@ -1690,12 +1698,12 @@ namespace HtmlAgilityPack
             bool isExplicitEnd = false;
 
             var parent = _lastparentnode.Name;
-            var nodeName = Text.Substring(_currentnode._namestartindex, _index - _currentnode._namestartindex - 1);
+            int nodeNameLength = _index - _currentnode._namestartindex - 1;
 
             switch (parent)
             {
                 case "title":
-                    isExplicitEnd = nodeName == "title";
+                    isExplicitEnd = Utilities.StringSubstringEquals(Text, "title", _currentnode._namestartindex, nodeNameLength, StringComparison.Ordinal);
                     break;
             }
 
@@ -1756,7 +1764,7 @@ namespace HtmlAgilityPack
                     ReadDocumentEncoding(_currentnode);
 
                     // remember last node of this kind
-                    HtmlNode prev = Utilities.GetDictionaryValueOrNull(Lastnodes, _currentnode.Name);
+                    HtmlNode prev = Utilities.GetDictionaryValueOrDefault(Lastnodes, _currentnode.Name);
 
                     _currentnode._prevwithsamename = prev;
                     Lastnodes[_currentnode.Name] = _currentnode;

--- a/src/HtmlAgilityPack.Shared/HtmlEntity.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlEntity.cs
@@ -630,9 +630,9 @@ namespace HtmlAgilityPack
                                         string e = entity.ToString();
                                         try
  										{
-											string codeStr = e.Substring(1).Trim().ToLower();
+											string codeStr = e.Substring(1).Trim();
 											int fromBase;
-											if (codeStr.StartsWith("x"))
+											if (codeStr.StartsWith("x", StringComparison.OrdinalIgnoreCase))
 											{
 												fromBase = 16;
 												codeStr = codeStr.Substring(1);

--- a/src/HtmlAgilityPack.Shared/HtmlNode.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlNode.cs
@@ -479,7 +479,7 @@ namespace HtmlAgilityPack
 					if (_name == null)
 						_optimizedName = string.Empty;
 					else
-						_optimizedName = _name.ToLower();
+						_optimizedName = OwnerDocument.OptionLowerCaseWhenParsing ? _name.ToLowerInvariant() : _name;
 				}
 				return _optimizedName;
 			}
@@ -604,12 +604,10 @@ namespace HtmlAgilityPack
 				throw new ArgumentNullException("name");
 			}
 
-			if (!ElementsFlags.ContainsKey(name))
-			{
+			HtmlElementFlag flag;
+			if (!ElementsFlags.TryGetValue(name, out flag))
 				return false;
-			}
 
-			HtmlElementFlag flag = ElementsFlags[name];
 			return (flag & HtmlElementFlag.CanOverlap) != 0;
 		}
 
@@ -652,12 +650,10 @@ namespace HtmlAgilityPack
 				throw new ArgumentNullException("name");
 			}
 
-			if (!ElementsFlags.ContainsKey(name))
-			{
+			HtmlElementFlag flag;
+			if (!ElementsFlags.TryGetValue(name, out flag))
 				return false;
-			}
 
-			HtmlElementFlag flag = ElementsFlags[name];
 			return (flag & HtmlElementFlag.CData) != 0;
 		}
 
@@ -673,12 +669,10 @@ namespace HtmlAgilityPack
 				throw new ArgumentNullException("name");
 			}
 
-			if (!ElementsFlags.ContainsKey(name))
-			{
+			HtmlElementFlag flag;
+			if (!ElementsFlags.TryGetValue(name, out flag))
 				return false;
-			}
 
-			HtmlElementFlag flag = ElementsFlags[name];
 			return (flag & HtmlElementFlag.Closed) != 0;
 		}
 
@@ -711,12 +705,10 @@ namespace HtmlAgilityPack
 				return true;
 			}
 
-			if (!ElementsFlags.ContainsKey(name))
-			{
+			HtmlElementFlag flag;
+			if (!ElementsFlags.TryGetValue(name, out flag))
 				return false;
-			}
 
-			HtmlElementFlag flag = ElementsFlags[name];
 			return (flag & HtmlElementFlag.Empty) != 0;
 		}
 
@@ -1057,9 +1049,8 @@ namespace HtmlAgilityPack
 		/// <returns></returns>
 		public IEnumerable<HtmlNode> Descendants(string name)
 		{
-			name = name.ToLowerInvariant();
 			foreach (HtmlNode node in Descendants())
-				if (node.Name.Equals(name))
+				if (String.Equals(node.Name, name, StringComparison.OrdinalIgnoreCase))
 					yield return node;
 		}
 
@@ -1844,7 +1835,7 @@ namespace HtmlAgilityPack
 				if (_ownerdocument.Openednodes != null)
 					_ownerdocument.Openednodes.Remove(_outerstartindex);
 
-				HtmlNode self = Utilities.GetDictionaryValueOrNull(_ownerdocument.Lastnodes, Name);
+				HtmlNode self = Utilities.GetDictionaryValueOrDefault(_ownerdocument.Lastnodes, Name);
 				if (self == this)
 				{
 					_ownerdocument.Lastnodes.Remove(Name);

--- a/src/HtmlAgilityPack.Shared/HtmlNodeCollection.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlNodeCollection.cs
@@ -63,9 +63,8 @@ namespace HtmlAgilityPack
         {
             get
             {
-                nodeName = nodeName.ToLower();
                 for (int i = 0; i < _items.Count; i++)
-                    if (_items[i].Name.Equals(nodeName))
+                    if (string.Equals(_items[i].Name, nodeName, StringComparison.OrdinalIgnoreCase))
                         return _items[i];
 
                 return null;
@@ -276,7 +275,7 @@ namespace HtmlAgilityPack
         {
             foreach (HtmlNode node in items)
             {
-                if (node.Name.ToLower().Contains(name))
+                if (node.Name.IndexOf(name, StringComparison.OrdinalIgnoreCase) != -1)
                     return node;
                 if (!node.HasChildNodes) continue;
                 HtmlNode returnNode = FindFirst(node.ChildNodes, name);

--- a/src/HtmlAgilityPack.Shared/NameValuePairList.cs
+++ b/src/HtmlAgilityPack.Shared/NameValuePairList.cs
@@ -50,7 +50,7 @@ namespace HtmlAgilityPack
         {
             if (name == null)
                 return _allPairs;
-            return _pairsWithName.ContainsKey(name) ? _pairsWithName[name] : new List<KeyValuePair<string,string>>();
+            return Utilities.GetDictionaryValueOrDefault(_pairsWithName, name, new List<KeyValuePair<string,string>>());
         }
 
         internal string GetNameValuePairValue(string name)
@@ -91,13 +91,11 @@ namespace HtmlAgilityPack
 
                 // index by name
                 List<KeyValuePair<string, string>> al;
-                if (!_pairsWithName.ContainsKey(nvp.Key))
+                if (!_pairsWithName.TryGetValue(nvp.Key, out al))
                 {
                     al = new List<KeyValuePair<string, string>>();
-                    _pairsWithName[nvp.Key] = al;
+                    _pairsWithName.Add(nvp.Key, al);
                 }
-                else
-                    al = _pairsWithName[nvp.Key];
 
                 al.Add(nvp);
             }

--- a/src/HtmlAgilityPack.Shared/Utilities.cs
+++ b/src/HtmlAgilityPack.Shared/Utilities.cs
@@ -5,15 +5,28 @@
 // More projects: http://www.zzzprojects.com/
 // Copyright © ZZZ Projects Inc. 2014 - 2017. All rights reserved.
 
+using System;
 using System.Collections.Generic;
 
 namespace HtmlAgilityPack
 {
     internal static class Utilities
     {
-        public static TValue GetDictionaryValueOrNull<TKey,TValue>(Dictionary<TKey,TValue> dict, TKey key) where TKey: class
+        public static TValue GetDictionaryValueOrDefault<TKey,TValue>(Dictionary<TKey,TValue> dict, TKey key, TValue defaultValue = default(TValue)) where TKey: class
         {
-            return dict.ContainsKey(key) ? dict[key] : default(TValue);
+            TValue value;
+            if (!dict.TryGetValue(key, out value))
+                return defaultValue;
+            return value;
+        }
+
+        public static bool StringSubstringEquals(string haystack, string needle, int startIndex, int count, StringComparison comparisonType = StringComparison.Ordinal)
+        {
+            int index = haystack.IndexOf(needle, startIndex, count, comparisonType);
+            if (index != startIndex)
+                return false;
+
+            return needle.Length == count;
         }
     }
 }


### PR DESCRIPTION
Mainly reduced throwaway strings allocations, and used Dictionary.TryGetValue where possible to avoid double lookup.