### PR TITLE
Node not updating parent

### DIFF
--- a/src/HtmlAgilityPack.Shared/HtmlNodeCollection.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlNodeCollection.cs
@@ -108,6 +108,7 @@ namespace HtmlAgilityPack
         public void Add(HtmlNode node)
         {
             _items.Add(node);
+            node.ParentNode = _parentnode;
         }
 
         /// <summary>

--- a/src/HtmlAgilityPack.Tests/HtmlAgilityPack.Tests.csproj
+++ b/src/HtmlAgilityPack.Tests/HtmlAgilityPack.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\Solutions\packages\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\Solutions\packages\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -16,6 +17,8 @@
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
     <SccProvider>SAK</SccProvider>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -83,6 +86,12 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\Solutions\packages\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\Solutions\packages\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/HtmlAgilityPack.Tests/HtmlDocumentTests.cs
+++ b/src/HtmlAgilityPack.Tests/HtmlDocumentTests.cs
@@ -612,14 +612,52 @@ namespace HtmlAgilityPack.Tests
         }
 
         //[Test]
-    //public void TestOptionTag()
-    //{
-    //    var html = "<select><option>Select a cell</option><option>C1</option><option value='\"c2\"'></select>";
+        //public void TestOptionTag()
+        //{
+        //    var html = "<select><option>Select a cell</option><option>C1</option><option value='\"c2\"'></select>";
 
-    //    string output = "<select><option>Select a cell</option><option>C1</option><option value='\"c2\"'></option></select>";
-    //    var document = new HtmlDocument();
-    //    document.LoadHtml(html);
-    //    Assert.AreEqual(output, document.DocumentNode.OuterHtml);
-    //}
-}
+        //    string output = "<select><option>Select a cell</option><option>C1</option><option value='\"c2\"'></option></select>";
+        //    var document = new HtmlDocument();
+        //    document.LoadHtml(html);
+        //    Assert.AreEqual(output, document.DocumentNode.OuterHtml);
+        //}
+
+
+        [Test]
+        public void VerifyChildDivParent()
+        {
+            var doc = new HtmlDocument();
+            doc.LoadHtml("<html><body></body></html>");
+
+            var div = HtmlNode.CreateNode("<div class='1'/>");
+            var div2 = HtmlNode.CreateNode("<div class='2'/>");
+
+            doc.DocumentNode.ChildNodes.Add(div);
+            div.ChildNodes.Add(div2);
+
+            Assert.AreEqual(div.Name, div2.ParentNode.Name);
+
+        }
+
+
+        [Test]
+        public void ChildIsRemovedFromParent()
+        {
+            var doc = new HtmlDocument();
+            doc.LoadHtml("<html><body></body></html>");
+
+            var div = HtmlNode.CreateNode("<div class='1'/>");
+            var div2 = HtmlNode.CreateNode("<div class='2'/>");
+
+            div.ChildNodes.Add(div2);
+            doc.DocumentNode.ChildNodes.Add(div);
+
+
+            div.FirstChild.Remove();
+
+            Assert.AreEqual(0, div.ChildNodes.Count);
+
+        }
+
+    }
 }

--- a/src/HtmlAgilityPack.Tests/packages.config
+++ b/src/HtmlAgilityPack.Tests/packages.config
@@ -8,4 +8,5 @@
   <package id="NUnit.Extension.TeamCityEventListener" version="1.0.0" targetFramework="net40" />
   <package id="NUnit.Extension.VSProjectLoader" version="3.4.0" targetFramework="net40" />
   <package id="NUnit.Runners" version="3.4.0" targetFramework="net40" />
+  <package id="NUnit3TestAdapter" version="3.9.0" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Hello.  I made the following changes (fixes).  

- Added NUnit test runner for VS 2017
- When a Node is added to another Node, the parent was not being updated.  It was still referencing document as a parent.  See unit test VerifyChildDivParent()
- Due to this, when the added node was removed from the parent, the remove was not working.  See unit test ChildIsRemovedFromParent()

This kept causing me to scratch my head with a production issue as why the Remove() was not working.

A potential issue, is that the parent will always be the _last_ parent not the _first_ parent.  If you add a node to multiple other Nodes, it may cause unintended behavior.  Perhaps parent node should be a collection?  Perhaps a node need to be made immutable.. ie copy on add?  