### PR TITLE
Avoid infinite recursion

### DIFF
--- a/src/HtmlAgilityPack.Shared/MixedCodeDocumentFragment.cs
+++ b/src/HtmlAgilityPack.Shared/MixedCodeDocumentFragment.cs
@@ -59,7 +59,7 @@ namespace HtmlAgilityPack
                 {
                     _fragmentText = Doc._text.Substring(Index, Length);
                 }
-                return FragmentText;
+                return _fragmentText;
             }
             internal set { _fragmentText = value; }
         }

--- a/src/HtmlAgilityPack.Shared/MixedCodeDocumentFragmentList.cs
+++ b/src/HtmlAgilityPack.Shared/MixedCodeDocumentFragmentList.cs
@@ -57,7 +57,7 @@ namespace HtmlAgilityPack
         /// </summary>
         public MixedCodeDocumentFragment this[int index]
         {
-            get { return _items[index] as MixedCodeDocumentFragment; }
+            get { return _items[index]; }
         }
 
 #endregion


### PR DESCRIPTION
The property `FragmentText` calls itself instead of the backing field `_fragmentText`.