### PR TITLE
String optimizations

### DIFF
--- a/src/HtmlAgilityPack.Shared/HtmlAttribute.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlAttribute.cs
@@ -261,7 +261,7 @@ namespace HtmlAgilityPack
 
                 i++;
             }
-            return "@" + Name + "[" + i + "]";
+            return "@" + Name + "[" + i.ToString() + "]";
         }
 
         #endregion

--- a/src/HtmlAgilityPack.Shared/HtmlDocument.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlDocument.cs
@@ -1604,8 +1604,9 @@ namespace HtmlAgilityPack
                         // check buffer end
                         if ((_currentnode._namelength + 3) <= (Text.Length - (_index - 1)))
                         {
-                            if (string.Compare(Text.Substring(_index - 1, _currentnode._namelength + 2),
-                                    "</" + _currentnode.Name, StringComparison.OrdinalIgnoreCase) == 0)
+                            if (Text[_index - 1] == '<' &&
+                                Text[_index] == '/' &&
+                                string.Compare(Text, _index + 1, _currentnode.Name, 0, _currentnode._namelength, StringComparison.OrdinalIgnoreCase) == 0)
                             {
                                 int c = Text[_index - 1 + 2 + _currentnode.Name.Length];
                                 if ((c == '>') || (IsWhiteSpace(c)))
@@ -1850,7 +1851,7 @@ namespace HtmlAgilityPack
             if ((close) || (!_currentnode._starttag))
             {
                 if ((OptionStopperNodeName != null) && (_remainder == null) &&
-                    (string.Compare(_currentnode.Name, OptionStopperNodeName, StringComparison.OrdinalIgnoreCase) == 0))
+                    (string.Equals(_currentnode.Name, OptionStopperNodeName, StringComparison.OrdinalIgnoreCase)))
                 {
                     _remainderOffset = index;
                     _remainder = Text.Substring(_remainderOffset);
@@ -1904,7 +1905,7 @@ namespace HtmlAgilityPack
             HtmlAttribute att = node.Attributes["http-equiv"];
             if (att == null)
                 return;
-            if (string.Compare(att.Value, "content-type", StringComparison.OrdinalIgnoreCase) != 0)
+            if (!string.Equals(att.Value, "content-type", StringComparison.OrdinalIgnoreCase))
                 return;
             HtmlAttribute content = node.Attributes["content"];
             if (content != null)

--- a/src/HtmlAgilityPack.Shared/HtmlEntity.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlEntity.cs
@@ -646,7 +646,9 @@ namespace HtmlAgilityPack
                                         }
                                         catch
                                         {
-                                            sb.Append("&#" + e + ";");
+                                            sb.Append("&#")
+                                              .Append(e)
+                                              .Append(';');
                                         }
                                     }
                                     else
@@ -656,7 +658,9 @@ namespace HtmlAgilityPack
                                         if (!_entityValue.TryGetValue(entity.ToString(), out code))
                                         {
                                             // nope
-                                            sb.Append("&" + entity + ";");
+                                            sb.Append('&')
+                                              .Append(entity)
+                                              .Append(';');
                                         }
                                         else
                                         {
@@ -671,7 +675,8 @@ namespace HtmlAgilityPack
 
                             case '&':
                                 // new entity start without end, it was not an entity...
-                                sb.Append("&" + entity);
+                                sb.Append('&')
+                                  .Append(entity);
                                 entity.Remove(0, entity.Length);
                                 break;
 
@@ -681,7 +686,8 @@ namespace HtmlAgilityPack
                                 {
                                     // unknown stuff, just don't touch it
                                     state = ParseState.Text;
-                                    sb.Append("&" + entity);
+                                    sb.Append('&')
+                                      .Append(entity);
                                     entity.Remove(0, entity.Length);
                                 }
                                 break;
@@ -693,7 +699,8 @@ namespace HtmlAgilityPack
             // finish the work
             if (state == ParseState.EntityStart)
             {
-                sb.Append("&" + entity);
+                sb.Append('&')
+                  .Append(entity);
             }
             return sb.ToString();
         }
@@ -784,11 +791,15 @@ namespace HtmlAgilityPack
 
                     if ((entity == null) || (!useNames))
                     {
-                        sb.Append("&#" + code + ";");
+                        sb.Append("&#")
+                          .Append(code)
+                          .Append(';');
                     }
                     else
                     {
-                        sb.Append("&" + entity + ";");
+                        sb.Append('&')
+                          .Append(entity)
+                          .Append(';');
                     }
                 }
                 else

--- a/src/HtmlAgilityPack.Shared/HtmlNode.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlNode.cs
@@ -1548,7 +1548,7 @@ namespace HtmlAgilityPack
 				    if (_ownerdocument.OptionOutputAsXml)
 				    {
                         var commentNode = (HtmlCommentNode)this;
-				        if (!_ownerdocument.BackwardCompatibility && commentNode.Comment.ToLowerInvariant().StartsWith("<!doctype"))
+				        if (!_ownerdocument.BackwardCompatibility && commentNode.Comment.StartsWith("<!doctype", StringComparison.OrdinalIgnoreCase))
 				        {
 				            outText.Write(commentNode.Comment);
                         }
@@ -1949,7 +1949,7 @@ namespace HtmlAgilityPack
 				int i = 0;
 				foreach (HtmlNode n in ChildNodes)
 				{
-					WriteAttribute(outText, _ownerdocument.CreateAttribute("_child_" + i,
+					WriteAttribute(outText, _ownerdocument.CreateAttribute("_child_" + i.ToString(),
 																		   n.Name));
 					i++;
 				}
@@ -1990,7 +1990,7 @@ namespace HtmlAgilityPack
 
 				i++;
 			}
-			return Name + "[" + i + "]";
+			return Name + "[" + i.ToString() + "]";
 		}
 
         private bool IsSingleElementNode()

--- a/src/HtmlAgilityPack.Shared/HtmlNodeNavigator.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlNodeNavigator.cs
@@ -235,7 +235,7 @@ namespace HtmlAgilityPack
         {
             get
             {
-                InternalTrace(">" + (_currentnode.Attributes.Count > 0));
+                InternalTrace(">" + (_currentnode.Attributes.Count > 0).ToString());
                 return (_currentnode.Attributes.Count > 0);
             }
         }
@@ -247,7 +247,7 @@ namespace HtmlAgilityPack
         {
             get
             {
-                InternalTrace(">" + (_currentnode.ChildNodes.Count > 0));
+                InternalTrace(">" + (_currentnode.ChildNodes.Count > 0).ToString());
                 return (_currentnode.ChildNodes.Count > 0);
             }
         }
@@ -259,7 +259,7 @@ namespace HtmlAgilityPack
         {
             get
             {
-                InternalTrace(">" + !HasChildren);
+                InternalTrace(">" + (!HasChildren).ToString());
                 // REVIEW: is this ok?
                 return !HasChildren;
             }
@@ -329,31 +329,31 @@ namespace HtmlAgilityPack
                 switch (_currentnode.NodeType)
                 {
                     case HtmlNodeType.Comment:
-                        InternalTrace(">" + XPathNodeType.Comment);
+                        InternalTrace(">" + XPathNodeType.Comment.ToString());
                         return XPathNodeType.Comment;
 
                     case HtmlNodeType.Document:
-                        InternalTrace(">" + XPathNodeType.Root);
+                        InternalTrace(">" + XPathNodeType.Root.ToString());
                         return XPathNodeType.Root;
 
                     case HtmlNodeType.Text:
-                        InternalTrace(">" + XPathNodeType.Text);
+                        InternalTrace(">" + XPathNodeType.Text.ToString());
                         return XPathNodeType.Text;
 
                     case HtmlNodeType.Element:
                         {
                             if (_attindex != -1)
                             {
-                                InternalTrace(">" + XPathNodeType.Attribute);
+                                InternalTrace(">" + XPathNodeType.Attribute.ToString());
                                 return XPathNodeType.Attribute;
                             }
-                            InternalTrace(">" + XPathNodeType.Element);
+                            InternalTrace(">" + XPathNodeType.Element.ToString());
                             return XPathNodeType.Element;
                         }
 
                     default:
                         throw new NotImplementedException("Internal error: Unhandled HtmlNodeType: " +
-                                                          _currentnode.NodeType);
+                                                          _currentnode.NodeType.ToString());
                 }
             }
         }
@@ -378,7 +378,7 @@ namespace HtmlAgilityPack
         {
             get
             {
-                InternalTrace("nt=" + _currentnode.NodeType);
+                InternalTrace("nt=" + _currentnode.NodeType.ToString());
                 switch (_currentnode.NodeType)
                 {
                     case HtmlNodeType.Comment:
@@ -405,7 +405,7 @@ namespace HtmlAgilityPack
 
                     default:
                         throw new NotImplementedException("Internal error: Unhandled HtmlNodeType: " +
-                                                          _currentnode.NodeType);
+                                                          _currentnode.NodeType.ToString());
                 }
             }
         }
@@ -481,7 +481,7 @@ namespace HtmlAgilityPack
                 InternalTrace(">false");
                 return false;
             }
-            InternalTrace(">" + (nav._currentnode == _currentnode));
+            InternalTrace(">" + (nav._currentnode == _currentnode).ToString());
             return (nav._currentnode == _currentnode);
         }
 
@@ -498,9 +498,9 @@ namespace HtmlAgilityPack
                 InternalTrace(">false (nav is not an HtmlNodeNavigator)");
                 return false;
             }
-            InternalTrace("moveto oid=" + nav.GetHashCode()
+            InternalTrace("moveto oid=" + nav.GetHashCode().ToString()
                           + ", n:" + nav._currentnode.Name
-                          + ", a:" + nav._attindex);
+                          + ", a:" + nav._attindex.ToString());
 
             if (nav._doc == _doc)
             {

--- a/src/HtmlAgilityPack.Shared/MixedCodeDocument.cs
+++ b/src/HtmlAgilityPack.Shared/MixedCodeDocument.cs
@@ -435,7 +435,7 @@ namespace HtmlAgilityPack
                     case ParseState.Text:
                         if (_index + TokenCodeStart.Length < _text.Length)
                         {
-                            if (_text.Substring(_index - 1, TokenCodeStart.Length) == TokenCodeStart)
+                            if (string.CompareOrdinal(_text, _index - 1, TokenCodeStart, 0, TokenCodeStart.Length) == 0)
                             {
                                 _state = ParseState.Code;
                                 _currentfragment.Length = _index - 1 - _currentfragment.Index;
@@ -449,7 +449,7 @@ namespace HtmlAgilityPack
                     case ParseState.Code:
                         if (_index + TokenCodeEnd.Length < _text.Length)
                         {
-                            if (_text.Substring(_index - 1, TokenCodeEnd.Length) == TokenCodeEnd)
+                            if (string.CompareOrdinal(_text, _index - 1, TokenCodeEnd, 0, TokenCodeEnd.Length) == 0)
                             {
                                 _state = ParseState.Text;
                                 _currentfragment.Length = _index + TokenCodeEnd.Length - _currentfragment.Index;


### PR DESCRIPTION
* Instead of calling `ToLower[Invariant]` on a string, we can use  a `StringComparison` overload of `Equals` or `Compare`.
* Instead of calling `Substring` on a string, we can use `String.Compare[Ordinal]` to perform equality checks on  parts of a string.
* Concatenating a primitive without calling `ToString()` will box it in an `object` on which `ToString()` is then called.
* Instead of concatenating strings and then appending the concatenated string to a `StringBuilder` we can avoid some allocations by appending each string to the `StringBuilder` instead.
* Delayed some invocations of e.g. `ÌsHtml` as they were only used inside an if.