### PR TITLE
Add 2 function for search nodes

### DIFF
--- a/src/HtmlAgilityPack.Shared/HtmlNode.Xpath.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlNode.Xpath.cs
@@ -58,6 +58,31 @@ namespace HtmlAgilityPack
         }
 
         /// <summary>
+        /// Selects a list of nodes matching the <see cref="XPath"/> expression.
+        /// </summary>
+        /// <param name="xpath">The XPath expression.</param>
+        /// <returns>An <see cref="HtmlNodeCollection"/> containing a collection of nodes matching the <see cref="XPath"/> query, or <c>null</c> if no node matched the XPath expression.</returns>
+        public HtmlNodeCollection SelectNodes(XPathExpression xpath)
+        {
+            HtmlNodeNavigator nav = new HtmlNodeNavigator(_ownerdocument, this);
+            HtmlNodeCollection list = new HtmlNodeCollection(null);
+
+            XPathNodeIterator it = nav.Select(xpath);
+            while (it.MoveNext())
+            {
+                var node = (HtmlNodeNavigator)it.Current;
+                list.Add(node.CurrentNode);
+            }
+
+            if (list.Count == 0 && !OwnerDocument.OptionEmptyCollection)
+            {
+                return null;
+            }
+
+            return list;
+        }
+
+        /// <summary>
         /// Selects the first XmlNode that matches the XPath expression.
         /// </summary>
         /// <param name="xpath">The XPath expression. May not be null.</param>
@@ -79,6 +104,30 @@ namespace HtmlAgilityPack
             HtmlNodeNavigator node = (HtmlNodeNavigator) it.Current;
             return node.CurrentNode;
         }
+
+        /// <summary>
+        /// Selects a list of nodes matching the <see cref="XPath"/> expression.
+        /// </summary>
+        /// <param name="xpath">The XPath expression.</param>
+        /// <returns>An <see cref="HtmlNodeCollection"/> containing a collection of nodes matching the <see cref="XPath"/> query, or <c>null</c> if no node matched the XPath expression.</returns>
+        public HtmlNode SelectSingleNode(XPathExpression xpath)
+        {
+            if (xpath == null)
+            {
+                throw new ArgumentNullException("xpath");
+            }
+
+            HtmlNodeNavigator nav = new HtmlNodeNavigator(OwnerDocument, this);
+            XPathNodeIterator it = nav.Select(xpath);
+            if (!it.MoveNext())
+            {
+                return null;
+            }
+
+            HtmlNodeNavigator node = (HtmlNodeNavigator)it.Current;
+            return node.CurrentNode;
+        }
+
     }
 }
 #endif


### PR DESCRIPTION
_Add 2 functioins:_
1. SelectNodes(XPathExpression xpath)
2. SelectSingleNode(XPathExpression xpath)

**XPathExpression** provides a typed class that represents a compiled XPath expression.

It's different from a string, because we can use **XPathExpression** to customize **xpath** functions, or do more. But with **string**, we can only use the **xpath** built-in functions.