### PR TITLE
Feature/preserve xml namespaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ Z.Lab/
 _ReSharper.*
 *.ReSharper.user
 *.resharper.user 
+.vs/

--- a/src/HtmlAgilityPack.NETStandard/HtmlAgilityPack.NETStandard.csproj
+++ b/src/HtmlAgilityPack.NETStandard/HtmlAgilityPack.NETStandard.csproj
@@ -17,8 +17,8 @@
     <Company>ZZZ Projects Inc.</Company>
     <Product>Html Agility Pack</Product>
     <Description />
-    <PostBuildEvent>del /f /q $(SolutionDir)..\Nuget\lib\NetStandard1_6\*
-copy "$(TargetDir)Html*.*" $(SolutionDir)..\Nuget\lib\NetStandard1_6\*</PostBuildEvent>
+    <PostBuildEvent>del /f /q "$(SolutionDir)..\Nuget\lib\NetStandard1_6\*"
+copy "$(TargetDir)Html*.*" "$(SolutionDir)..\Nuget\lib\NetStandard1_6\*"</PostBuildEvent>
     <Authors>ZZZ Projects Inc.</Authors>
     <AssemblyVersion>1.6.0.0</AssemblyVersion>
     <FileVersion>1.6.0.0</FileVersion>

--- a/src/HtmlAgilityPack.Shared/HtmlAttribute.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlAttribute.cs
@@ -183,7 +183,7 @@ namespace HtmlAgilityPack
 
         internal string XmlName
         {
-            get { return HtmlDocument.GetXmlName(Name, true); }
+            get { return HtmlDocument.GetXmlName(Name, true, OwnerDocument.OptionPreserveXmlNamespaces); }
         }
 
         internal string XmlValue

--- a/src/HtmlAgilityPack.Shared/HtmlDocument.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlDocument.cs
@@ -125,7 +125,7 @@ namespace HtmlAgilityPack
 
 
         /// <summary>
-        /// If used together <see cref="OptionOutputAsXml"/> and enabled, Xml namespaces in element names are preserved. Default is false. 
+        /// If used together with <see cref="OptionOutputAsXml"/> and enabled, Xml namespaces in element names are preserved. Default is false.
         /// </summary>
         public bool OptionPreserveXmlNamespaces;
 

--- a/src/HtmlAgilityPack.Shared/HtmlDocument.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlDocument.cs
@@ -123,6 +123,12 @@ namespace HtmlAgilityPack
         /// </summary>
         public bool OptionOutputAsXml;
 
+
+        /// <summary>
+        /// If used together <see cref="OptionOutputAsXml"/> and enabled, Xml namespaces in element names are preserved. Default is false. 
+        /// </summary>
+        public bool OptionPreserveXmlNamespaces;
+
         /// <summary>
         /// Defines if attribute value output must be optimized (not bound with double quotes if it is possible). Default is false.
         /// </summary>
@@ -301,10 +307,10 @@ namespace HtmlAgilityPack
         /// <returns>A string that is a valid XML name.</returns>
         public static string GetXmlName(string name)
         {
-            return GetXmlName(name, false);
+            return GetXmlName(name, false, false);
         }
 
-        public static string GetXmlName(string name, bool isAttribute)
+        public static string GetXmlName(string name, bool isAttribute, bool preserveXmlNamespaces)
         {
             string xmlname = string.Empty;
             bool nameisok = true;
@@ -315,7 +321,7 @@ namespace HtmlAgilityPack
                 if (((name[i] >= 'a') && (name[i] <= 'z')) ||
                     ((name[i] >= 'A') && (name[i] <= 'Z')) ||
                     ((name[i] >= '0') && (name[i] <= '9')) ||
-                    (isAttribute && name[i] == ':') ||
+                    ((isAttribute || preserveXmlNamespaces) && name[i] == ':') ||
                     //                    (name[i]==':') || (name[i]=='_') || (name[i]=='-') || (name[i]=='.')) // these are bads in fact
                     (name[i] == '_') || (name[i] == '-') || (name[i] == '.'))
                 {

--- a/src/HtmlAgilityPack.Shared/HtmlNode.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlNode.cs
@@ -1684,7 +1684,7 @@ namespace HtmlAgilityPack
 
                             if (name.Trim().Length == 0)
                                 break;
-                            name = HtmlDocument.GetXmlName(name);
+                            name = HtmlDocument.GetXmlName(name, false, _ownerdocument.OptionPreserveXmlNamespaces);
                         }
                         else
                             break;

--- a/src/HtmlAgilityPack.Tests/HtmlDocumentTests.cs
+++ b/src/HtmlAgilityPack.Tests/HtmlDocumentTests.cs
@@ -811,6 +811,49 @@ namespace HtmlAgilityPack.Tests
             Assert.AreEqual(0, doc1.DocumentNode.OwnerDocument.ParseErrors.Count());
         }
 
+        [Test]
+        public void SanitizeXmlElementNameWithColon()
+        {
+            var input = @"<RootElement xmlns:MyNamespace=""value"">
+  <value:element />
+</RootElement>";
+            var htmlDoc = new HtmlAgilityPack.HtmlDocument();
+            htmlDoc.LoadHtml(input);
+            htmlDoc.OptionDefaultStreamEncoding = System.Text.Encoding.UTF8; 
+            htmlDoc.OptionOutputAsXml = true;
+            htmlDoc.OptionOutputOriginalCase = true;
+            var xmlDoc = htmlDoc.DocumentNode.WriteTo();
+
+            var expected = @"<?xml version=""1.0"" encoding=""utf-8""?>" +
+                           @"<RootElement xmlns:MyNamespace=""value"">
+  <_value3a_element></_value3a_element>
+</RootElement>";
+
+            Assert.AreEqual(expected, xmlDoc);
+        }
+
+        [Test]
+        public void DoesNotSanitizeXmlElementNameWithColonWhenConfiguredToPreserveXmlNamespaces()
+        {
+            var input = @"<RootElement xmlns:MyNamespace=""value"">
+  <value:element />
+</RootElement>";
+            var htmlDoc = new HtmlAgilityPack.HtmlDocument();
+            htmlDoc.LoadHtml(input);
+            htmlDoc.OptionDefaultStreamEncoding = System.Text.Encoding.UTF8; 
+            htmlDoc.OptionOutputAsXml = true;
+            htmlDoc.OptionOutputOriginalCase = true;
+            htmlDoc.OptionPreserveXmlNamespaces = true;
+            var xmlDoc = htmlDoc.DocumentNode.WriteTo();
+
+            var expected = @"<?xml version=""1.0"" encoding=""utf-8""?>" +
+                           @"<RootElement xmlns:MyNamespace=""value"">
+  <value:element></value:element>
+</RootElement>";
+
+            Assert.AreEqual(expected, xmlDoc);
+        }
+
 
         [HasXPath]
         public class StackOverflowPage

--- a/src/HtmlAgilityPack/HtmlAgilityPack.csproj
+++ b/src/HtmlAgilityPack/HtmlAgilityPack.csproj
@@ -95,7 +95,7 @@
   <Import Project="..\HtmlAgilityPack.Shared\HtmlAgilityPack.Shared.projitems" Label="Shared" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>del /f /q $(SolutionDir)..\Nuget\lib\Net20\*
-copy "$(TargetDir)Html*.*" $(SolutionDir)..\Nuget\lib\Net20\</PostBuildEvent>
+    <PostBuildEvent>del /f /q "$(SolutionDir)..\Nuget\lib\Net20\*"
+copy "$(TargetDir)Html*.*" "$(SolutionDir)..\Nuget\lib\Net20\"</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/src/HtmlAgilityPack/HtmlAgilityPack.fx.4.0-CP.csproj
+++ b/src/HtmlAgilityPack/HtmlAgilityPack.fx.4.0-CP.csproj
@@ -96,7 +96,7 @@
   <Import Project="..\HtmlAgilityPack.Shared\HtmlAgilityPack.Shared.projitems" Label="Shared" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>del /f /q $(SolutionDir)..\Nuget\lib\Net40-client\*
-copy "$(TargetDir)Html*.*" $(SolutionDir)..\Nuget\lib\Net40-client\</PostBuildEvent>
+    <PostBuildEvent>del /f /q "$(SolutionDir)..\Nuget\lib\Net40-client\*"
+copy "$(TargetDir)Html*.*" "$(SolutionDir)..\Nuget\lib\Net40-client\"</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/src/HtmlAgilityPack/HtmlAgilityPack.fx.4.0.csproj
+++ b/src/HtmlAgilityPack/HtmlAgilityPack.fx.4.0.csproj
@@ -97,7 +97,7 @@
   <Import Project="..\HtmlAgilityPack.Shared\HtmlAgilityPack.Shared.projitems" Label="Shared" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>del /f /q $(SolutionDir)..\Nuget\lib\Net40\*
-copy "$(TargetDir)Html*.*" $(SolutionDir)..\Nuget\lib\Net40\</PostBuildEvent>
+    <PostBuildEvent>del /f /q "$(SolutionDir)..\Nuget\lib\Net40\*"
+copy "$(TargetDir)Html*.*" "$(SolutionDir)..\Nuget\lib\Net40\"</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/src/HtmlAgilityPack/HtmlAgilityPack.fx.4.5.csproj
+++ b/src/HtmlAgilityPack/HtmlAgilityPack.fx.4.5.csproj
@@ -99,7 +99,7 @@
   <Import Project="..\HtmlAgilityPack.Shared\HtmlAgilityPack.Shared.projitems" Label="Shared" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>del /f /q $(SolutionDir)..\Nuget\lib\Net45\*
-copy "$(TargetDir)Html*.*" $(SolutionDir)..\Nuget\lib\Net45\</PostBuildEvent>
+    <PostBuildEvent>del /f /q "$(SolutionDir)..\Nuget\lib\Net45\*"
+copy "$(TargetDir)Html*.*" "$(SolutionDir)..\Nuget\lib\Net45\"</PostBuildEvent>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Related to #168 

Add option to preserve Xml namespaces in element names when serializing to Xml, e.g. keep `namespace:ElementName` instead of transforming it to `_namespace3a_ElementName`.
This is controlled by setting `OptionPreserveXmlNamespaces` on the document to `true`.