### PR TITLE
Expose HTMLNode and HTMLAttribute exact position

### DIFF
--- a/src/HtmlAgilityPack.Shared/HtmlAttribute.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlAttribute.cs
@@ -68,6 +68,22 @@ namespace HtmlAgilityPack
         }
 
         /// <summary>
+        /// Gets the stream position of the value of this attribute in the document, relative to the start of the document.
+        /// </summary>
+        public int ValueStartIndex
+        {
+            get { return _valuestartindex; }
+        }
+
+        /// <summary>
+        /// Gets the length of the value.
+        /// </summary>
+        public int ValueLength
+        {
+            get { return _valuelength; }
+        }
+
+        /// <summary>
         /// Gets the qualified name of the attribute.
         /// </summary>
         public string Name

--- a/src/HtmlAgilityPack.Shared/HtmlNode.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlNode.cs
@@ -228,7 +228,10 @@ namespace HtmlAgilityPack
             get { return !HasClosingAttributes ? new HtmlAttributeCollection(this) : _endnode.Attributes; }
         }
 
-        internal HtmlNode EndNode
+        /// <summary>
+        /// Gets the closing tag of the node, null if the node is self-closing.
+        /// </summary>
+        public HtmlNode EndNode
         {
             get { return _endnode; }
         }
@@ -459,6 +462,30 @@ namespace HtmlAgilityPack
         {
             get { return _lineposition; }
             internal set { _lineposition = value; }
+        }
+
+        /// <summary>
+        /// Gets the stream position of the area between the opening and closing tag of the node, relative to the start of the document.
+        /// </summary>
+        public int InnerStartIndex
+        {
+            get { return _innerstartindex; }
+        }
+
+        /// <summary>
+        /// Gets the length of the area between the opening and closing tag of the node.
+        /// </summary>
+        public int InnerLength
+        {
+            get { return _innerlength; }
+        }
+
+        /// <summary>
+        /// Gets the length of the entire node, opening and closing tag included.
+        /// </summary>
+        public int OuterLength
+        {
+            get { return _outerlength; }
         }
 
         /// <summary>


### PR DESCRIPTION
Related to #170 

* Expose ```HtmlAttribute._valuestartindex``` and ```HtmlAttribute._valuelength``` via read-only properties.
* Expose ```HtmlNode._innerstartindex```, ```HtmlNode._innerlength```, ```HtmlNode._outerlength``` and ```HtmlAttribute._endnode``` via read-only properties.