### PR TITLE
Correct StreamPosition in text node inside script element

### DIFF
--- a/src/HtmlAgilityPack.Shared/HtmlDocument.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlDocument.cs
@@ -1639,6 +1639,7 @@ namespace HtmlAgilityPack
                                         _currentnode._outerstartindex +
                                         _currentnode._outerlength);
                                     script._outerlength = _index - 1 - script._outerstartindex;
+                                    script._streamposition = script._outerstartindex;
                                     _currentnode.AppendChild(script);
 
 

--- a/src/HtmlAgilityPack.Tests/HtmlDocumentTests.cs
+++ b/src/HtmlAgilityPack.Tests/HtmlDocumentTests.cs
@@ -620,6 +620,27 @@ namespace HtmlAgilityPack.Tests
         }
 
         [Test]
+        public void TextInsideScriptTagShouldHaveCorrectStreamPosition()
+        {
+            {
+                var document = new HtmlDocument();
+                document.LoadHtml(@"<scrapt>foo</scrapt>");
+                var scraptText = document.DocumentNode.FirstChild.FirstChild;
+                Assert.AreEqual(8, scraptText.StreamPosition);
+                Assert.AreEqual(1, scraptText.Line);
+                Assert.AreEqual(9, scraptText.LinePosition);
+            }
+            {
+                var document = new HtmlDocument();
+                document.LoadHtml(@"<script>foo</script>");
+                var scriptText = document.DocumentNode.FirstChild.FirstChild;
+                Assert.AreEqual(8, scriptText.StreamPosition);
+//            Assert.AreEqual(1, scriptText.Line);
+//            Assert.AreEqual(9, scriptText.LinePosition);
+            }
+        }
+
+        [Test]
         public void TestNumericTag()
         {
             var html = @"<div><1</div>";


### PR DESCRIPTION
Related to #175.
Probably it's a good idea to implement other indexes - Line and LinePosition.