### PR TITLE
fixed HTML corruption caused by unclosed tags processing

### DIFF
--- a/src/HtmlAgilityPack.Shared/HtmlNode.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlNode.cs
@@ -1774,6 +1774,10 @@ namespace HtmlAgilityPack
                             {
                                 outText.Write("></" + name + ">");
                             }
+                            else 
+                            {
+                                outText.Write(">");
+                            }
                         }
                     }
 

--- a/src/HtmlAgilityPack.Tests/HtmlDocumentTests.cs
+++ b/src/HtmlAgilityPack.Tests/HtmlDocumentTests.cs
@@ -740,6 +740,18 @@ namespace HtmlAgilityPack.Tests
         }
 
         [Test]
+        public void TestHandleNestedAnchors()
+        {
+            var inHtml =       "<a><a>";
+            var expectedHtml = "<a><a></a>";
+
+            var doc = new HtmlDocument();
+            doc.LoadHtml(inHtml);
+
+            Assert.AreEqual(expectedHtml, doc.DocumentNode.OuterHtml);
+        }
+
+        [Test]
         public void TestInnerText()
         {
             var inHtml = @"<html>


### PR DESCRIPTION
Bug: loading and saving the following document:

```html
<a><a>
```

will result in invalid HTML (the outer A is missing the '>'):

```html
<a<a></a>
```

I fixed it + added a unit test to cover this case.

