### PR TITLE
Fixed for indexing strings out of bounds

### DIFF
--- a/src/HtmlAgilityPack.Shared/HtmlAttribute.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlAttribute.cs
@@ -170,7 +170,10 @@ namespace HtmlAgilityPack
 
                 if (_value == null)
                 {
-                    _value = _ownerdocument.Text.Substring(_valuestartindex, _valuelength);
+                    if (_ownerdocument.Text != null && _valuestartindex + _valuelength <= _ownerdocument.Text.Length)
+                        _value = _ownerdocument.Text.Substring(_valuestartindex, _valuelength);
+                    else
+                        _value = "";
 
                     if (!_ownerdocument.BackwardCompatibility)
                     {

--- a/src/HtmlAgilityPack.Shared/HtmlNode.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlNode.cs
@@ -565,7 +565,9 @@ namespace HtmlAgilityPack
                     return string.Empty;
                 }
 
-                return _ownerdocument.Text.Substring(_outerstartindex, _outerlength);
+                if (_ownerdocument.Text != null && _outerstartindex + _outerlength <= _ownerdocument.Text.Length)
+                    return _ownerdocument.Text.Substring(_outerstartindex, _outerlength);
+                return string.Empty;
             }
         }
 


### PR DESCRIPTION
I don't know if I had bad XML from Tesseract, but your code was blowing up in these two spots where the position + the number of characters was greater than the length of the string.

So I added a check to make sure it is a valid offset and if it isn't I return a empty string.

