### PR TITLE
Turned off TRACE constant for Release build configuration

### DIFF
--- a/src/HtmlAgilityPack.NETStandard/HtmlAgilityPack.NETStandard.csproj
+++ b/src/HtmlAgilityPack.NETStandard/HtmlAgilityPack.NETStandard.csproj
@@ -29,7 +29,7 @@ copy "$(TargetDir)Html*.*" "$(SolutionDir)..\Nuget\lib\NetStandard1_6\*"</PostBu
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DefineConstants>TRACE;NETSTANDARD;NETSTANDARD1_6</DefineConstants>
+    <DefineConstants>NETSTANDARD;NETSTANDARD1_6</DefineConstants>
     <DocumentationFile>bin\Release\netstandard1.6\HtmlAgilityPack.xml</DocumentationFile>
   </PropertyGroup>
 


### PR DESCRIPTION
Turned off TRACE constant for Release build configuration of Net standard project. #265 #207 