### PR TITLE
refactor Entitize method, use HtmlEncode, add unit tests

### DIFF
--- a/src/HtmlAgilityPack.Shared/HtmlEntity.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlEntity.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 
 namespace HtmlAgilityPack
@@ -766,14 +767,6 @@ namespace HtmlAgilityPack
         /// <param name="entitizeQuotAmpAndLtGt">If set to true, the [quote], [ampersand], [lower than] and [greather than] characters will be entitized.</param>
         /// <returns>The result text</returns>
         public static string Entitize(string text, bool useNames, bool entitizeQuotAmpAndLtGt)
-//        _entityValue.Add("quot", 34);    // quotation mark = APL quote, U+0022 ISOnum 
-//        _entityName.Add(34, "quot");
-//        _entityValue.Add("amp", 38);    // ampersand, U+0026 ISOnum 
-//        _entityName.Add(38, "amp");
-//        _entityValue.Add("lt", 60);    // less-than sign, U+003C ISOnum 
-//        _entityName.Add(60, "lt");
-//        _entityValue.Add("gt", 62);    // greater-than sign, U+003E ISOnum 
-//        _entityName.Add(62, "gt");
         {
             if (text == null)
                 return null;
@@ -782,28 +775,10 @@ namespace HtmlAgilityPack
                 return text;
 
             StringBuilder sb = new StringBuilder(text.Length);
-            for (int i = 0; i < text.Length; i++)
+            TextElementEnumerator enumerator = StringInfo.GetTextElementEnumerator(text);
+            while (enumerator.MoveNext())
             {
-                int code = text[i];
-                if ((code > 127) ||
-                    (entitizeQuotAmpAndLtGt && ((code == 34) || (code == 38) || (code == 60) || (code == 62))))
-                {
-                    string entity;
-                    EntityName.TryGetValue(code, out entity);
-
-                    if ((entity == null) || (!useNames))
-                    {
-                        sb.Append("&#" + code + ";");
-                    }
-                    else
-                    {
-                        sb.Append("&" + entity + ";");
-                    }
-                }
-                else
-                {
-                    sb.Append(text[i]);
-                }
+                sb.Append(System.Net.WebUtility.HtmlEncode(enumerator.GetTextElement()));
             }
 
             return sb.ToString();

--- a/src/Tests/HtmlAgilityPack.Tests.Net45/HtmlAgilityPack.Tests.Net45.csproj
+++ b/src/Tests/HtmlAgilityPack.Tests.Net45/HtmlAgilityPack.Tests.Net45.csproj
@@ -56,6 +56,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="HtmlDocumentTests.cs" />
+    <Compile Include="HtmlEntityTests.cs" />
     <Compile Include="HtmlNode.Tests.cs" />
     <Compile Include="UnitTest1.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Tests/HtmlAgilityPack.Tests.Net45/HtmlEntityTests.cs
+++ b/src/Tests/HtmlAgilityPack.Tests.Net45/HtmlEntityTests.cs
@@ -1,0 +1,23 @@
+﻿using NUnit.Framework;
+
+namespace HtmlAgilityPack.Tests.fx._4._5
+{
+    public class HtmlEntityTests
+    {
+        [Test]
+        public void Entitize_PassEmojiUnicode_ShouldCorrectlyEntitize()
+        {
+            string result = HtmlEntity.Entitize("😂");
+
+            Assert.AreEqual("&#128514;", result);
+        }
+
+        [Test]
+        public void Entitize_PassSimpleText_ShouldCorrectlyEntitize()
+        {
+            string result = HtmlEntity.Entitize("qwerty");
+
+            Assert.AreEqual("qwerty", result);
+        }
+    }
+}


### PR DESCRIPTION
proposal with fix for #323 

@JonathanMagnan hi there, can you please take a look at changes for Entitize method. I'm strongly suggesting use standard System.Net.WebUtility.HtmlEncode method for entitize unicode characters.
If it looks OK, I can improve DeEntitize method, just use System.Net.WebUtility.HtmlDecode method instead of complicated logic. Also I think it's really useful to get rid off _entityName, _entityValue dictionaries.