### PR TITLE
Remove redundant package references from .NET Standard 2.0.

### DIFF
--- a/src/HtmlAgilityPack.NETStandard2_0/HtmlAgilityPack.NETStandard2_0.csproj
+++ b/src/HtmlAgilityPack.NETStandard2_0/HtmlAgilityPack.NETStandard2_0.csproj
@@ -35,11 +35,4 @@
 
   <Import Project="..\HtmlAgilityPack.Shared\HtmlAgilityPack.Shared.projitems" Label="Shared" />
 
-  <ItemGroup>
-    <PackageReference Include="System.Net.Http" Version="4.3.2" />
-    <PackageReference Include="System.Xml.XmlDocument" Version="4.3.0" />
-    <PackageReference Include="System.Xml.XPath" Version="4.3.0" />
-    <PackageReference Include="System.Xml.XPath.XmlDocument" Version="4.3.0" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
These are not needed in .NET Standard 2.0 and significantly clutter the dependency graph of any library that uses HAP.