### PR TITLE
explictily set line breaks and whitespace for tests that need it

### DIFF
--- a/src/Tests/HtmlAgilityPack.Tests.Net45/HtmlDocumentTests.cs
+++ b/src/Tests/HtmlAgilityPack.Tests.Net45/HtmlDocumentTests.cs
@@ -140,21 +140,23 @@ namespace HtmlAgilityPack.Tests
                 Assert.AreEqual(8, scriptText.LinePosition);
             }
             {
+                // this test relies on exact character counts so line endings are added explicitly
                 var document = new HtmlAgilityPack.HtmlDocument();
-                document.LoadHtml(@"
-<scrapt>foo</scrapt>");
+                document.LoadHtml(string.Join("\r\n", 
+                    @"",
+                    @"<scrapt>foo</scrapt>"));
                 var scraptText = document.DocumentNode.LastChild.FirstChild;
                 //   var aa = scraptText.FirstChild;
                 Assert.AreEqual(10, scraptText.StreamPosition);
                 Assert.AreEqual(2, scraptText.Line);
                 Assert.AreEqual(8, scraptText.LinePosition);
             }
-
-
             {
+                // this test relies on exact character counts so line endings are added explicitly
                 var document = new HtmlAgilityPack.HtmlDocument();
-                document.LoadHtml(@"
-<script>foo</script>");
+                document.LoadHtml(string.Join("\r\n", 
+                    @"",
+                    "<script>foo</script>"));
                 var scriptText = document.DocumentNode.LastChild.FirstChild;
                 Assert.AreEqual(10, scriptText.StreamPosition);
                 Assert.AreEqual(2, scriptText.Line);

--- a/src/Tests/HtmlAgilityPack.Tests.Net45/HtmlNode.Tests.cs
+++ b/src/Tests/HtmlAgilityPack.Tests.Net45/HtmlNode.Tests.cs
@@ -30,19 +30,21 @@ namespace HtmlAgilityPack.Tests
         [Test]
         public void ScriptingText()
         {
-            var html = @"<?xml version=""1.0"" encoding=""UTF-8"" ?>
-<html xmlns=""http://www.w3.org/1999/xhtml"">
-<head>
-    <title>SEE title</title>
-	<script>SEE script </script>
-	<style>SEE style</style>
-</head>
-<body>
-<script>NOTSEE script</script>
-<div>222<script>NOTSEE script</script>
-<style>NOTSEE style</style></div>
-</body>
-</html>";
+            // this test relies on exact characters so line endings and specific whitespace characters are added explicitly
+            var html = string.Join("\r\n",
+                @"<?xml version=""1.0"" encoding=""UTF-8"" ?>",
+                @"<html xmlns=""http://www.w3.org/1999/xhtml"">",
+                @"<head>",
+                @"    <title>SEE title</title>", // prefix of four spaces
+                "\t<script>SEE script </script>", // prefix of one tab
+                "\t<style>SEE style</style>", // prefix of one tab
+                @"</head>",
+                @"<body>",
+                @"<script>NOTSEE script</script>",
+                @"<div>222<script>NOTSEE script</script>",
+                @"<style>NOTSEE style</style></div>",
+                @"</body>",
+                @"</html>");
 
             {
                 HtmlAgilityPack.HtmlDocument htmlDocument = new HtmlAgilityPack.HtmlDocument();


### PR DESCRIPTION
This commit fixes tests `TextInsideScriptTagShouldHaveCorrectStreamPosition` and `ScriptingText` which may fail depending on how the local environment is set to deal with line endings when pulling from the repository.

Additionally, `ScriptingText` relies on tab whitespace which is now set explicitly with `\t` for readability.