### PR TITLE
Fix OptionOutputOptimizeAttributeValues

### DIFF
--- a/src/HtmlAgilityPack.Shared/HtmlNode.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlNode.cs
@@ -2356,24 +2356,35 @@ namespace HtmlAgilityPack
 					}
 				}
 
-				if (!isWithoutValue)
-				{
-					var value = quoteType == AttributeValueQuote.DoubleQuote ? !att.Value.StartsWith("@") ? att.Value.Replace("\"", "&quot;") :
-				   att.Value : quoteType == AttributeValueQuote.SingleQuote ?  att.Value.Replace("'", "&#39;") : att.Value;
-					if (_ownerdocument.OptionOutputOptimizeAttributeValues)
-						if (att.Value.IndexOfAny(new char[] {(char) 10, (char) 13, (char) 9, ' '}) < 0)
-							outText.Write(" " + name + "=" + att.Value);
-						else
-							outText.Write(" " + name + "=" + quote + value + quote);
-					else
-						outText.Write(" " + name + "=" + quote + value + quote);
-				}
-				else
+                if (!isWithoutValue)
                 {
-					outText.Write(" " + name);
-				}
+                    string value = att.Value;
 
-			}
+                    switch (quoteType)
+                    {
+                        case AttributeValueQuote.DoubleQuote:
+                            value = value.Replace("\"", "&quot;");
+                            break;
+
+                        case AttributeValueQuote.SingleQuote:
+                            value = value.Replace("'", "&#39;");
+                            break;
+                    }
+
+                    if (_ownerdocument.OptionOutputOptimizeAttributeValues)
+                        if (att.Value.Length > 0 && att.Value.IndexOfAny(new char[] { '\r', '\n', '\t', ' ', '=' }) == -1)
+                            outText.Write(" " + name + "=" + att.Value);
+                        else
+                            outText.Write(" " + name + "=" + quote + value + quote);
+                    else
+                        outText.Write(" " + name + "=" + quote + value + quote);
+                }
+                else
+                {
+                    outText.Write(" " + name);
+                }
+
+            }
 		}
 
 		internal void WriteAttributes(TextWriter outText, bool closing)


### PR DESCRIPTION
I am currently working on a project that transforms HTML documents using HtmlAgilityPack. One of the project's interests is to minimize the size of the output HTML. I am setting `HtmlDocument.OptionOutputOptimizeAttributeValues` to `true` to remove quotes from attribute values when possible. However, the current system of omitting quotation marks is too aggressive for most general purposes.

This pull request fixes a few issues:
1. If the attribute value is blank, quotes should be included. For example, `alt=""` not `alt=`. The HTML standards interpret the latter as a missing attribute value.
2. If the attribute value contains an equals sign, quotes should be included. For example, `src="https://example.com?q=search+query"` not `src=https://example.com?q =search+query`. The HTML standards interpret the latter as a missing attribute name.