### PR TITLE
Added ability to set the maximum redirects

### DIFF
--- a/src/HtmlAgilityPack.Shared/HtmlWeb.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlWeb.cs
@@ -89,6 +89,7 @@ namespace HtmlAgilityPack
 
         private string _cachePath;
         private bool _fromCache;
+        private int _maxAutoRedirects = 50;
         private int _requestDuration;
         private Uri _responseUri;
         private HttpStatusCode _statusCode = HttpStatusCode.OK;
@@ -801,6 +802,15 @@ namespace HtmlAgilityPack
         /// <summary>Gets or sets the automatic decompression.</summary>
         /// <value>The automatic decompression.</value>
         public DecompressionMethods AutomaticDecompression { get; set; }
+
+        /// <summary>
+        /// Maximum number of redirects that will be followed. Default value is 50.
+        /// </summary>
+        public int MaxAutoRedirects
+        {
+            set { if (value <= 0) { throw new ArgumentOutOfRangeException(); } else { _maxAutoRedirects = value; } }
+            get { return _maxAutoRedirects; }
+        }
 
         /// <summary>
         /// Gets or sets the timeout value in milliseconds. Must be greater than zero. A value of -1 sets the timeout to be infinite.
@@ -1581,6 +1591,7 @@ namespace HtmlAgilityPack
             bool oldFile = false;
 
             req = WebRequest.Create(uri) as HttpWebRequest;
+            req.MaximumAutomaticRedirections = MaxAutoRedirects;
             req.Timeout = Timeout;
             req.Method = method;
             req.UserAgent = UserAgent;
@@ -1853,6 +1864,7 @@ namespace HtmlAgilityPack
             using (var client = new HttpClient(handler))
             {
                 client.Timeout = TimeSpan.FromMilliseconds(Timeout);
+                handler.MaxAutomaticRedirections = MaxAutoRedirects;
 
                 if(CaptureRedirect)
                 {

--- a/src/HtmlAgilityPack.Shared/HtmlWeb.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlWeb.cs
@@ -804,8 +804,10 @@ namespace HtmlAgilityPack
         public DecompressionMethods AutomaticDecompression { get; set; }
 
         /// <summary>
-        /// Maximum number of redirects that will be followed. Default value is 50.
+        /// Maximum number of redirects that will be followed.
+        /// To disable redirects, do not set the value to 0, please set CaptureRedirect to 'true'.
         /// </summary>
+        /// <value>Must be greater than 0, Default is 50.</value>
         public int MaxAutoRedirects
         {
             set { if (value <= 0) { throw new ArgumentOutOfRangeException(); } else { _maxAutoRedirects = value; } }


### PR DESCRIPTION
So I am building a web scraper and I noticed sometimes it will follow a long set of redirects, probably from a scam website or something. But I looked at the documentation and the maximum redirects that HttpWebRequest and HttpClientHandler will follow is 50 by default. I think this is too much so I added the ability to adjust the maximum number of redirects that will be followed. This is so I can save on bandwidth and compute power.

When the redirect limit is hit, `HtmlWeb.StatusCode` will be a 3xx status code. If the resource is reached before the redirect limit, then it will be a 2xx status code.

[HttpWebRequest.MaximumAutomaticRedirections Property](https://learn.microsoft.com/en-us/dotnet/api/system.net.httpwebrequest.maximumautomaticredirections?view=net-7.0#system-net-httpwebrequest-maximumautomaticredirections)

[HttpClientHandler.MaxAutomaticRedirections Property](https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpclienthandler.maxautomaticredirections?view=net-7.0#system-net-http-httpclienthandler-maxautomaticredirections)