### PR TITLE
Use backwards for loop instead of linq for performance in AttributeCollection.Remove

### DIFF
--- a/src/HtmlAgilityPack.Shared/HtmlAttributeCollection.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlAttributeCollection.cs
@@ -8,7 +8,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace HtmlAgilityPack
 {
@@ -368,19 +367,13 @@ namespace HtmlAgilityPack
                 throw new ArgumentNullException("name");
             }
             
-            List<int> listToRemove = new List<int>();
-            for (int i = 0; i < items.Count; i++)
+            for (int i = items.Count - 1; i >= 0; i--)
             {
                 HtmlAttribute att = items[i];
                 if (String.Equals(att.Name, name, StringComparison.OrdinalIgnoreCase))
                 {
-                    listToRemove.Add(i);
+                    RemoveAt(i);
                 }
-            }
-
-            foreach(var i in listToRemove.OrderByDescending(x => x))
-			{ 
-                RemoveAt(i);
             }
         }
 

--- a/src/Tests/HtmlAgilityPack.Tests.Net45/HtmlDocumentTests.cs
+++ b/src/Tests/HtmlAgilityPack.Tests.Net45/HtmlDocumentTests.cs
@@ -565,6 +565,24 @@ namespace HtmlAgilityPack.Tests
         }
 
         [Test]
+        public void TestRemoveAttribute()
+        {
+            var output = @"<h1>This is new heading</h1>";
+
+            string html = "<h1 a=\"foo\" b=\"bar\" A=\"baz\">This is new heading</h1>";
+
+            var htmlDoc = new HtmlDocument();
+            htmlDoc.LoadHtml(html);
+
+            var h1Node = htmlDoc.DocumentNode.SelectSingleNode("//h1");
+
+            h1Node.Attributes.Remove("a");
+            h1Node.Attributes.Remove("b");
+
+            Assert.AreEqual(h1Node.OuterHtml, output);
+        }
+
+        [Test]
         public void TestAttributeDeEntitizeValue()
         {
             var html =


### PR DESCRIPTION
Avoids `List` allocation and slower `OrderByDescending`.