### PR TITLE
Fix copyright symbol encoding; force UTF-8-BOM encoding for C# files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+# C# files
+[*.cs]
+charset = utf-8-bom

--- a/src/HtmlAgilityPack.Net20/Properties/AssemblyInfo.cs
+++ b/src/HtmlAgilityPack.Net20/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// HtmlAgilityPack V1.0 - Simon Mourier <simon underscore mourier at hotmail dot com>
+﻿// HtmlAgilityPack V1.0 - Simon Mourier <simon underscore mourier at hotmail dot com>
 
 using System;
 using System.Reflection;

--- a/src/HtmlAgilityPack.Net20/Properties/AssemblyInfo.cs
+++ b/src/HtmlAgilityPack.Net20/Properties/AssemblyInfo.cs
@@ -21,7 +21,7 @@ using System.Security;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("ZZZ Projects Inc.")]
 [assembly: AssemblyProduct("Html Agility Pack")]
-[assembly: AssemblyCopyright("Copyright © ZZZ Projects Inc.")]
+[assembly: AssemblyCopyright("Copyright Â© ZZZ Projects Inc.")]
 [assembly: AssemblyTrademark("SQL & .NET Tools")]
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(true)]

--- a/src/HtmlAgilityPack.Net40-client/Properties/AssemblyInfo.cs
+++ b/src/HtmlAgilityPack.Net40-client/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// HtmlAgilityPack V1.0 - Simon Mourier <simon underscore mourier at hotmail dot com>
+﻿// HtmlAgilityPack V1.0 - Simon Mourier <simon underscore mourier at hotmail dot com>
 
 using System;
 using System.Reflection;

--- a/src/HtmlAgilityPack.Net40-client/Properties/AssemblyInfo.cs
+++ b/src/HtmlAgilityPack.Net40-client/Properties/AssemblyInfo.cs
@@ -21,7 +21,7 @@ using System.Security;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("ZZZ Projects Inc.")]
 [assembly: AssemblyProduct("Html Agility Pack")]
-[assembly: AssemblyCopyright("Copyright © ZZZ Projects Inc.")]
+[assembly: AssemblyCopyright("Copyright Â© ZZZ Projects Inc.")]
 [assembly: AssemblyTrademark("SQL & .NET Tools")]
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(true)]

--- a/src/HtmlAgilityPack.Net40/Properties/AssemblyInfo.cs
+++ b/src/HtmlAgilityPack.Net40/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// HtmlAgilityPack V1.0 - Simon Mourier <simon underscore mourier at hotmail dot com>
+﻿// HtmlAgilityPack V1.0 - Simon Mourier <simon underscore mourier at hotmail dot com>
 
 using System;
 using System.Reflection;

--- a/src/HtmlAgilityPack.Net40/Properties/AssemblyInfo.cs
+++ b/src/HtmlAgilityPack.Net40/Properties/AssemblyInfo.cs
@@ -21,7 +21,7 @@ using System.Security;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("ZZZ Projects Inc.")]
 [assembly: AssemblyProduct("Html Agility Pack")]
-[assembly: AssemblyCopyright("Copyright © ZZZ Projects Inc.")]
+[assembly: AssemblyCopyright("Copyright Â© ZZZ Projects Inc.")]
 [assembly: AssemblyTrademark("SQL & .NET Tools")]
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(true)]

--- a/src/HtmlAgilityPack.Net45/Properties/AssemblyInfo.cs
+++ b/src/HtmlAgilityPack.Net45/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// HtmlAgilityPack V1.0 - Simon Mourier <simon underscore mourier at hotmail dot com>
+﻿// HtmlAgilityPack V1.0 - Simon Mourier <simon underscore mourier at hotmail dot com>
 
 using System;
 using System.Reflection;

--- a/src/HtmlAgilityPack.Net45/Properties/AssemblyInfo.cs
+++ b/src/HtmlAgilityPack.Net45/Properties/AssemblyInfo.cs
@@ -21,7 +21,7 @@ using System.Security;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("ZZZ Projects Inc.")]
 [assembly: AssemblyProduct("Html Agility Pack")]
-[assembly: AssemblyCopyright("Copyright © ZZZ Projects Inc.")]
+[assembly: AssemblyCopyright("Copyright Â© ZZZ Projects Inc.")]
 [assembly: AssemblyTrademark("SQL & .NET Tools")]
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(true)]

--- a/src/HtmlAgilityPack.NetCore45/Properties/AssemblyInfo.cs
+++ b/src/HtmlAgilityPack.NetCore45/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// HtmlAgilityPack V1.0 - Simon Mourier <simon underscore mourier at hotmail dot com>
+﻿// HtmlAgilityPack V1.0 - Simon Mourier <simon underscore mourier at hotmail dot com>
 
 using System;
 using System.Reflection;

--- a/src/HtmlAgilityPack.NetCore45/Properties/AssemblyInfo.cs
+++ b/src/HtmlAgilityPack.NetCore45/Properties/AssemblyInfo.cs
@@ -21,7 +21,7 @@ using System.Security;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("ZZZ Projects Inc.")]
 [assembly: AssemblyProduct("Html Agility Pack")]
-[assembly: AssemblyCopyright("Copyright © ZZZ Projects Inc.")]
+[assembly: AssemblyCopyright("Copyright Â© ZZZ Projects Inc.")]
 [assembly: AssemblyTrademark("SQL & .NET Tools")]
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(true)]

--- a/src/HtmlAgilityPack.NetStandard1_3/AssemblyInfo.cs
+++ b/src/HtmlAgilityPack.NetStandard1_3/AssemblyInfo.cs
@@ -1,3 +1,3 @@
-using System;
+﻿using System;
 
 [assembly: CLSCompliant(true)]

--- a/src/HtmlAgilityPack.NetStandard1_6/AssemblyInfo.cs
+++ b/src/HtmlAgilityPack.NetStandard1_6/AssemblyInfo.cs
@@ -1,3 +1,3 @@
-using System;
+﻿using System;
 
 [assembly: CLSCompliant(true)]

--- a/src/HtmlAgilityPack.NetStandard2_0/AssemblyInfo.cs
+++ b/src/HtmlAgilityPack.NetStandard2_0/AssemblyInfo.cs
@@ -1,3 +1,3 @@
-using System;
+﻿using System;
 
 [assembly: CLSCompliant(true)]

--- a/src/HtmlAgilityPack.Portable-wp8/Properties/AssemblyInfo.cs
+++ b/src/HtmlAgilityPack.Portable-wp8/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// HtmlAgilityPack V1.0 - Simon Mourier <simon underscore mourier at hotmail dot com>
+﻿// HtmlAgilityPack V1.0 - Simon Mourier <simon underscore mourier at hotmail dot com>
 
 using System;
 using System.Reflection;

--- a/src/HtmlAgilityPack.Portable-wp8/Properties/AssemblyInfo.cs
+++ b/src/HtmlAgilityPack.Portable-wp8/Properties/AssemblyInfo.cs
@@ -21,7 +21,7 @@ using System.Security;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("ZZZ Projects Inc.")]
 [assembly: AssemblyProduct("Html Agility Pack")]
-[assembly: AssemblyCopyright("Copyright © ZZZ Projects Inc.")]
+[assembly: AssemblyCopyright("Copyright Â© ZZZ Projects Inc.")]
 [assembly: AssemblyTrademark("SQL & .NET Tools")]
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(true)]

--- a/src/HtmlAgilityPack.Portable-wp81/Properties/AssemblyInfo.cs
+++ b/src/HtmlAgilityPack.Portable-wp81/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// HtmlAgilityPack V1.0 - Simon Mourier <simon underscore mourier at hotmail dot com>
+﻿// HtmlAgilityPack V1.0 - Simon Mourier <simon underscore mourier at hotmail dot com>
 
 using System;
 using System.Reflection;

--- a/src/HtmlAgilityPack.Portable-wp81/Properties/AssemblyInfo.cs
+++ b/src/HtmlAgilityPack.Portable-wp81/Properties/AssemblyInfo.cs
@@ -21,7 +21,7 @@ using System.Security;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("ZZZ Projects Inc.")]
 [assembly: AssemblyProduct("Html Agility Pack")]
-[assembly: AssemblyCopyright("Copyright © ZZZ Projects Inc.")]
+[assembly: AssemblyCopyright("Copyright Â© ZZZ Projects Inc.")]
 [assembly: AssemblyTrademark("SQL & .NET Tools")]
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(true)]

--- a/src/HtmlAgilityPack.Shared/EncodingFoundException.cs
+++ b/src/HtmlAgilityPack.Shared/EncodingFoundException.cs
@@ -3,7 +3,7 @@
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE
 // More projects: http://www.zzzprojects.com/
-// Copyright © ZZZ Projects Inc. 2014 - 2017. All rights reserved.
+// Copyright Â© ZZZ Projects Inc. 2014 - 2017. All rights reserved.
 
 using System;
 using System.Text;

--- a/src/HtmlAgilityPack.Shared/EncodingFoundException.cs
+++ b/src/HtmlAgilityPack.Shared/EncodingFoundException.cs
@@ -1,4 +1,4 @@
-// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
+﻿// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
 // Website & Documentation: http://html-agility-pack.net
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE

--- a/src/HtmlAgilityPack.Shared/HtmlAttribute.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlAttribute.cs
@@ -3,7 +3,7 @@
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE
 // More projects: http://www.zzzprojects.com/
-// Copyright © ZZZ Projects Inc. 2014 - 2017. All rights reserved.
+// Copyright Â© ZZZ Projects Inc. 2014 - 2017. All rights reserved.
 
 #region
 

--- a/src/HtmlAgilityPack.Shared/HtmlAttribute.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlAttribute.cs
@@ -1,4 +1,4 @@
-// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
+﻿// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
 // Website & Documentation: http://html-agility-pack.net
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE

--- a/src/HtmlAgilityPack.Shared/HtmlAttributeCollection.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlAttributeCollection.cs
@@ -3,7 +3,7 @@
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE
 // More projects: http://www.zzzprojects.com/
-// Copyright © ZZZ Projects Inc. 2014 - 2017. All rights reserved.
+// Copyright Â© ZZZ Projects Inc. 2014 - 2017. All rights reserved.
 
 using System;
 using System.Collections;

--- a/src/HtmlAgilityPack.Shared/HtmlAttributeCollection.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlAttributeCollection.cs
@@ -1,4 +1,4 @@
-// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
+﻿// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
 // Website & Documentation: http://html-agility-pack.net
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE

--- a/src/HtmlAgilityPack.Shared/HtmlCmdLine.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlCmdLine.cs
@@ -3,7 +3,7 @@
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE
 // More projects: http://www.zzzprojects.com/
-// Copyright © ZZZ Projects Inc. 2014 - 2017. All rights reserved.
+// Copyright Â© ZZZ Projects Inc. 2014 - 2017. All rights reserved.
 
 using System;
 

--- a/src/HtmlAgilityPack.Shared/HtmlCmdLine.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlCmdLine.cs
@@ -1,4 +1,4 @@
-// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
+﻿// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
 // Website & Documentation: http://html-agility-pack.net
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE

--- a/src/HtmlAgilityPack.Shared/HtmlCommentNode.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlCommentNode.cs
@@ -3,7 +3,7 @@
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE
 // More projects: http://www.zzzprojects.com/
-// Copyright © ZZZ Projects Inc. 2014 - 2017. All rights reserved.
+// Copyright Â© ZZZ Projects Inc. 2014 - 2017. All rights reserved.
 
 namespace HtmlAgilityPack
 {

--- a/src/HtmlAgilityPack.Shared/HtmlCommentNode.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlCommentNode.cs
@@ -1,4 +1,4 @@
-// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
+﻿// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
 // Website & Documentation: http://html-agility-pack.net
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE

--- a/src/HtmlAgilityPack.Shared/HtmlConsoleListener.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlConsoleListener.cs
@@ -3,7 +3,7 @@
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE
 // More projects: http://www.zzzprojects.com/
-// Copyright © ZZZ Projects Inc. 2014 - 2017. All rights reserved.
+// Copyright Â© ZZZ Projects Inc. 2014 - 2017. All rights reserved.
 
 #if !NETSTANDARD1_3 && !NETSTANDARD1_6 && !METRO
 using System;

--- a/src/HtmlAgilityPack.Shared/HtmlConsoleListener.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlConsoleListener.cs
@@ -1,4 +1,4 @@
-// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
+﻿// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
 // Website & Documentation: http://html-agility-pack.net
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE

--- a/src/HtmlAgilityPack.Shared/HtmlDocument.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlDocument.cs
@@ -3,7 +3,7 @@
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE
 // More projects: http://www.zzzprojects.com/
-// Copyright © ZZZ Projects Inc. 2014 - 2017. All rights reserved.
+// Copyright Â© ZZZ Projects Inc. 2014 - 2017. All rights reserved.
 
 using System;
 using System.Collections.Generic;

--- a/src/HtmlAgilityPack.Shared/HtmlDocument.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlDocument.cs
@@ -1,4 +1,4 @@
-// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
+﻿// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
 // Website & Documentation: http://html-agility-pack.net
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE

--- a/src/HtmlAgilityPack.Shared/HtmlElementFlag.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlElementFlag.cs
@@ -3,7 +3,7 @@
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE
 // More projects: http://www.zzzprojects.com/
-// Copyright © ZZZ Projects Inc. 2014 - 2017. All rights reserved.
+// Copyright Â© ZZZ Projects Inc. 2014 - 2017. All rights reserved.
 
 using System;
 

--- a/src/HtmlAgilityPack.Shared/HtmlElementFlag.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlElementFlag.cs
@@ -1,4 +1,4 @@
-// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
+﻿// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
 // Website & Documentation: http://html-agility-pack.net
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE

--- a/src/HtmlAgilityPack.Shared/HtmlEntity.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlEntity.cs
@@ -3,7 +3,7 @@
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE
 // More projects: http://www.zzzprojects.com/
-// Copyright © ZZZ Projects Inc. 2014 - 2017. All rights reserved.
+// Copyright Â© ZZZ Projects Inc. 2014 - 2017. All rights reserved.
 
 using System;
 using System.Collections;

--- a/src/HtmlAgilityPack.Shared/HtmlEntity.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlEntity.cs
@@ -1,4 +1,4 @@
-// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
+﻿// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
 // Website & Documentation: http://html-agility-pack.net
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE

--- a/src/HtmlAgilityPack.Shared/HtmlNameTable.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlNameTable.cs
@@ -1,4 +1,4 @@
-// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
+﻿// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
 // Website & Documentation: http://html-agility-pack.net
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE

--- a/src/HtmlAgilityPack.Shared/HtmlNameTable.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlNameTable.cs
@@ -3,7 +3,7 @@
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE
 // More projects: http://www.zzzprojects.com/
-// Copyright © ZZZ Projects Inc. 2014 - 2017. All rights reserved.
+// Copyright Â© ZZZ Projects Inc. 2014 - 2017. All rights reserved.
 
 using System.Xml;
 

--- a/src/HtmlAgilityPack.Shared/HtmlNode.Encapsulator.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlNode.Encapsulator.cs
@@ -1,4 +1,4 @@
-// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
+﻿// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
 // Website & Documentation: http://html-agility-pack.net
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE

--- a/src/HtmlAgilityPack.Shared/HtmlNode.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlNode.cs
@@ -3,7 +3,7 @@
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE
 // More projects: http://www.zzzprojects.com/
-// Copyright © ZZZ Projects Inc. 2014 - 2017. All rights reserved.
+// Copyright Â© ZZZ Projects Inc. 2014 - 2017. All rights reserved.
 
 using System;
 using System.Collections;

--- a/src/HtmlAgilityPack.Shared/HtmlNode.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlNode.cs
@@ -1,4 +1,4 @@
-// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
+﻿// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
 // Website & Documentation: http://html-agility-pack.net
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE

--- a/src/HtmlAgilityPack.Shared/HtmlNodeCollection.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlNodeCollection.cs
@@ -3,7 +3,7 @@
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE
 // More projects: http://www.zzzprojects.com/
-// Copyright © ZZZ Projects Inc. 2014 - 2017. All rights reserved.
+// Copyright Â© ZZZ Projects Inc. 2014 - 2017. All rights reserved.
 
 using System;
 using System.Collections;

--- a/src/HtmlAgilityPack.Shared/HtmlNodeCollection.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlNodeCollection.cs
@@ -1,4 +1,4 @@
-// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
+﻿// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
 // Website & Documentation: http://html-agility-pack.net
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE

--- a/src/HtmlAgilityPack.Shared/HtmlNodeType.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlNodeType.cs
@@ -3,7 +3,7 @@
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE
 // More projects: http://www.zzzprojects.com/
-// Copyright © ZZZ Projects Inc. 2014 - 2017. All rights reserved.
+// Copyright Â© ZZZ Projects Inc. 2014 - 2017. All rights reserved.
 
 namespace HtmlAgilityPack
 {

--- a/src/HtmlAgilityPack.Shared/HtmlNodeType.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlNodeType.cs
@@ -1,4 +1,4 @@
-// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
+﻿// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
 // Website & Documentation: http://html-agility-pack.net
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE

--- a/src/HtmlAgilityPack.Shared/HtmlParseError.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlParseError.cs
@@ -3,7 +3,7 @@
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE
 // More projects: http://www.zzzprojects.com/
-// Copyright © ZZZ Projects Inc. 2014 - 2017. All rights reserved.
+// Copyright Â© ZZZ Projects Inc. 2014 - 2017. All rights reserved.
 
 namespace HtmlAgilityPack
 {

--- a/src/HtmlAgilityPack.Shared/HtmlParseError.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlParseError.cs
@@ -1,4 +1,4 @@
-// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
+﻿// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
 // Website & Documentation: http://html-agility-pack.net
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE

--- a/src/HtmlAgilityPack.Shared/HtmlParseErrorCode.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlParseErrorCode.cs
@@ -3,7 +3,7 @@
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE
 // More projects: http://www.zzzprojects.com/
-// Copyright © ZZZ Projects Inc. 2014 - 2017. All rights reserved.
+// Copyright Â© ZZZ Projects Inc. 2014 - 2017. All rights reserved.
 
 namespace HtmlAgilityPack
 {

--- a/src/HtmlAgilityPack.Shared/HtmlParseErrorCode.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlParseErrorCode.cs
@@ -1,4 +1,4 @@
-// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
+﻿// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
 // Website & Documentation: http://html-agility-pack.net
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE

--- a/src/HtmlAgilityPack.Shared/HtmlTextNode.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlTextNode.cs
@@ -3,7 +3,7 @@
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE
 // More projects: http://www.zzzprojects.com/
-// Copyright © ZZZ Projects Inc. 2014 - 2017. All rights reserved.
+// Copyright Â© ZZZ Projects Inc. 2014 - 2017. All rights reserved.
 
 namespace HtmlAgilityPack
 {

--- a/src/HtmlAgilityPack.Shared/HtmlTextNode.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlTextNode.cs
@@ -1,4 +1,4 @@
-// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
+﻿// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
 // Website & Documentation: http://html-agility-pack.net
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE

--- a/src/HtmlAgilityPack.Shared/HtmlWeb.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlWeb.cs
@@ -3,7 +3,7 @@
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE
 // More projects: http://www.zzzprojects.com/
-// Copyright © ZZZ Projects Inc. 2014 - 2017. All rights reserved.
+// Copyright Â© ZZZ Projects Inc. 2014 - 2017. All rights reserved.
 
 #if !METRO
 
@@ -1846,7 +1846,7 @@ namespace HtmlAgilityPack
                         }
                         catch
                         {
-                            // That’s fine, the content type was unknown so probably not HTML
+                            // That's fine, the content type was unknown so probably not HTML
                             // Perhaps trying to figure if the content contains some HTML before would be a better idea.
                         }
                     }
@@ -2079,7 +2079,7 @@ namespace HtmlAgilityPack
                             }
                             catch
                             {
-                                // That’s fine, the content type was unknown so probably not HTML
+                                // That's fine, the content type was unknown so probably not HTML
                                 // Perhaps trying to figure if the content contains some HTML before would be a better idea.
                             }
                         }

--- a/src/HtmlAgilityPack.Shared/HtmlWeb.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlWeb.cs
@@ -1,4 +1,4 @@
-// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
+﻿// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
 // Website & Documentation: http://html-agility-pack.net
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE

--- a/src/HtmlAgilityPack.Shared/HtmlWebException.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlWebException.cs
@@ -3,7 +3,7 @@
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE
 // More projects: http://www.zzzprojects.com/
-// Copyright © ZZZ Projects Inc. 2014 - 2017. All rights reserved.
+// Copyright Â© ZZZ Projects Inc. 2014 - 2017. All rights reserved.
 
 using System;
 

--- a/src/HtmlAgilityPack.Shared/HtmlWebException.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlWebException.cs
@@ -1,4 +1,4 @@
-// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
+﻿// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
 // Website & Documentation: http://html-agility-pack.net
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE

--- a/src/HtmlAgilityPack.Shared/IOLibrary.cs
+++ b/src/HtmlAgilityPack.Shared/IOLibrary.cs
@@ -3,7 +3,7 @@
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE
 // More projects: http://www.zzzprojects.com/
-// Copyright © ZZZ Projects Inc. 2014 - 2017. All rights reserved.
+// Copyright Â© ZZZ Projects Inc. 2014 - 2017. All rights reserved.
 
 #if !METRO
 using System.IO;

--- a/src/HtmlAgilityPack.Shared/IOLibrary.cs
+++ b/src/HtmlAgilityPack.Shared/IOLibrary.cs
@@ -1,4 +1,4 @@
-// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
+﻿// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
 // Website & Documentation: http://html-agility-pack.net
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE

--- a/src/HtmlAgilityPack.Shared/MixedCodeDocument.cs
+++ b/src/HtmlAgilityPack.Shared/MixedCodeDocument.cs
@@ -3,7 +3,7 @@
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE
 // More projects: http://www.zzzprojects.com/
-// Copyright © ZZZ Projects Inc. 2014 - 2017. All rights reserved.
+// Copyright Â© ZZZ Projects Inc. 2014 - 2017. All rights reserved.
 
 #if !METRO
 using System;

--- a/src/HtmlAgilityPack.Shared/MixedCodeDocument.cs
+++ b/src/HtmlAgilityPack.Shared/MixedCodeDocument.cs
@@ -1,4 +1,4 @@
-// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
+﻿// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
 // Website & Documentation: http://html-agility-pack.net
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE

--- a/src/HtmlAgilityPack.Shared/MixedCodeDocumentCodeFragment.cs
+++ b/src/HtmlAgilityPack.Shared/MixedCodeDocumentCodeFragment.cs
@@ -3,7 +3,7 @@
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE
 // More projects: http://www.zzzprojects.com/
-// Copyright © ZZZ Projects Inc. 2014 - 2017. All rights reserved.
+// Copyright Â© ZZZ Projects Inc. 2014 - 2017. All rights reserved.
 
 #if !METRO
 namespace HtmlAgilityPack

--- a/src/HtmlAgilityPack.Shared/MixedCodeDocumentCodeFragment.cs
+++ b/src/HtmlAgilityPack.Shared/MixedCodeDocumentCodeFragment.cs
@@ -1,4 +1,4 @@
-// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
+﻿// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
 // Website & Documentation: http://html-agility-pack.net
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE

--- a/src/HtmlAgilityPack.Shared/MixedCodeDocumentFragment.cs
+++ b/src/HtmlAgilityPack.Shared/MixedCodeDocumentFragment.cs
@@ -3,7 +3,7 @@
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE
 // More projects: http://www.zzzprojects.com/
-// Copyright © ZZZ Projects Inc. 2014 - 2017. All rights reserved.
+// Copyright Â© ZZZ Projects Inc. 2014 - 2017. All rights reserved.
 
 #if !METRO
 namespace HtmlAgilityPack

--- a/src/HtmlAgilityPack.Shared/MixedCodeDocumentFragment.cs
+++ b/src/HtmlAgilityPack.Shared/MixedCodeDocumentFragment.cs
@@ -1,4 +1,4 @@
-// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
+﻿// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
 // Website & Documentation: http://html-agility-pack.net
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE

--- a/src/HtmlAgilityPack.Shared/MixedCodeDocumentFragmentList.cs
+++ b/src/HtmlAgilityPack.Shared/MixedCodeDocumentFragmentList.cs
@@ -3,7 +3,7 @@
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE
 // More projects: http://www.zzzprojects.com/
-// Copyright © ZZZ Projects Inc. 2014 - 2017. All rights reserved.
+// Copyright Â© ZZZ Projects Inc. 2014 - 2017. All rights reserved.
 
 #if !METRO
 

--- a/src/HtmlAgilityPack.Shared/MixedCodeDocumentFragmentList.cs
+++ b/src/HtmlAgilityPack.Shared/MixedCodeDocumentFragmentList.cs
@@ -1,4 +1,4 @@
-// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
+﻿// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
 // Website & Documentation: http://html-agility-pack.net
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE

--- a/src/HtmlAgilityPack.Shared/MixedCodeDocumentFragmentType.cs
+++ b/src/HtmlAgilityPack.Shared/MixedCodeDocumentFragmentType.cs
@@ -3,7 +3,7 @@
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE
 // More projects: http://www.zzzprojects.com/
-// Copyright © ZZZ Projects Inc. 2014 - 2017. All rights reserved.
+// Copyright Â© ZZZ Projects Inc. 2014 - 2017. All rights reserved.
 
 #if !METRO
 namespace HtmlAgilityPack

--- a/src/HtmlAgilityPack.Shared/MixedCodeDocumentFragmentType.cs
+++ b/src/HtmlAgilityPack.Shared/MixedCodeDocumentFragmentType.cs
@@ -1,4 +1,4 @@
-// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
+﻿// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
 // Website & Documentation: http://html-agility-pack.net
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE

--- a/src/HtmlAgilityPack.Shared/MixedCodeDocumentTextFragment.cs
+++ b/src/HtmlAgilityPack.Shared/MixedCodeDocumentTextFragment.cs
@@ -3,7 +3,7 @@
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE
 // More projects: http://www.zzzprojects.com/
-// Copyright © ZZZ Projects Inc. 2014 - 2017. All rights reserved.
+// Copyright Â© ZZZ Projects Inc. 2014 - 2017. All rights reserved.
 
 #if !METRO
 namespace HtmlAgilityPack

--- a/src/HtmlAgilityPack.Shared/MixedCodeDocumentTextFragment.cs
+++ b/src/HtmlAgilityPack.Shared/MixedCodeDocumentTextFragment.cs
@@ -1,4 +1,4 @@
-// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
+﻿// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
 // Website & Documentation: http://html-agility-pack.net
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE

--- a/src/HtmlAgilityPack.Shared/NameValuePairList.cs
+++ b/src/HtmlAgilityPack.Shared/NameValuePairList.cs
@@ -3,7 +3,7 @@
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE
 // More projects: http://www.zzzprojects.com/
-// Copyright © ZZZ Projects Inc. 2014 - 2017. All rights reserved.
+// Copyright Â© ZZZ Projects Inc. 2014 - 2017. All rights reserved.
 
 using System;
 using System.Collections.Generic;

--- a/src/HtmlAgilityPack.Shared/NameValuePairList.cs
+++ b/src/HtmlAgilityPack.Shared/NameValuePairList.cs
@@ -1,4 +1,4 @@
-// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
+﻿// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
 // Website & Documentation: http://html-agility-pack.net
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE

--- a/src/HtmlAgilityPack.Shared/crc32.cs
+++ b/src/HtmlAgilityPack.Shared/crc32.cs
@@ -3,7 +3,7 @@
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE
 // More projects: http://www.zzzprojects.com/
-// Copyright © ZZZ Projects Inc. 2014 - 2017. All rights reserved.
+// Copyright Â© ZZZ Projects Inc. 2014 - 2017. All rights reserved.
 
 using System;
 

--- a/src/HtmlAgilityPack.Shared/crc32.cs
+++ b/src/HtmlAgilityPack.Shared/crc32.cs
@@ -1,4 +1,4 @@
-// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
+﻿// Description: Html Agility Pack - HTML Parsers, selectors, traversors, manupulators.
 // Website & Documentation: http://html-agility-pack.net
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE

--- a/src/Tests/HtmlAgilityPack.Tests.Net45/Properties/AssemblyInfo.cs
+++ b/src/Tests/HtmlAgilityPack.Tests.Net45/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 


### PR DESCRIPTION
## Issue

When opening some files in IDEs like Visual Studio or Rider, the developer gets notified that file was opened with UTF-8 encoding. In case of Visual Studio, it tells you that some characters were replaced with substitution character (�) and saving the file will not preserve the original contents; Rider also performs character replacement but preserves the original contents when file is saved.

<details>
<summary>Visual Studio 2022</summary>

![](https://github.com/zzzprojects/html-agility-pack/assets/57114830/498744ea-d9f9-4872-b435-7684370b5660)

Shows up as modal window, forces you to interact with it.

</details>

<details>
<summary>Rider</summary>

![](https://github.com/zzzprojects/html-agility-pack/assets/57114830/6b9afde2-3fd7-47ec-ac35-7bac68980783)

Shows up as notification in the notification bar above the code editor, can be ignored.

</details>

The reason why it's happening is that some files are encoded in ISO-8859-1 where the copyright symbol is a single byte (0xA9), which is incompatible with UTF-8 and forces an IDE or a text editor to perform the character substitution.

## Changes

* The copyright symbol is encoded as proper UTF-8 code point.
* Replaced weird apostrophes in _HtmlWeb.cs_ file with ASCII apostrophes (`'`). Those were either not rendered or rendered as �, depending on IDE/text editor.
* Re-encoded all C# files in UTF-8-BOM encoding.
* UTF-8-BOM encoding for C# files is now enforced in IDEs/text editors that support _.editorconfig_. I chose UTF-8-BOM because it's the default one Visual Studio uses for C#-related files and almost every file in the solution is already encoded in UTF-8-BOM.

## Result

The developer doesn't get annoyed with notifications/popups and in case of Visual Studio one doesn't need to be careful not to accidentally commit the substitution character.