### PR TITLE
Avoid creating new strings when parsing PcData

### DIFF
--- a/src/HtmlAgilityPack.Shared/HtmlDocument.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlDocument.cs
@@ -1741,8 +1741,16 @@ namespace HtmlAgilityPack
                         // check buffer end
                         if ((_currentnode._namelength + 3) <= (Text.Length - (_index - 1)))
                         {
-                            if (string.Compare(Text.Substring(_index - 1, _currentnode._namelength + 2),
-                                    "</" + _currentnode.Name, StringComparison.OrdinalIgnoreCase) == 0)
+                            var tagStartMatching = Text[_index - 1] == '<' && Text[_index] == '/';
+                            var tagMatching = string.Compare(
+                                    Text,
+                                    _index + 1,
+                                    _currentnode.Name,
+                                    0,
+                                    _currentnode._namelength,
+                                    StringComparison.OrdinalIgnoreCase)
+                                == 0;
+                            if (tagStartMatching && tagMatching)
                             {
                                 int c = Text[_index - 1 + 2 + _currentnode.Name.Length];
                                 if ((c == '>') || (IsWhiteSpace(c)))


### PR DESCRIPTION
Avoid string concat and substring operations to optimize memory usage.
This reduces memory usages by around 80MB on a local large html file.

![image](https://github.com/zzzprojects/html-agility-pack/assets/1222172/24c02508-f6c7-4b22-a6d9-e1e31e68d6cc)
