### PR TITLE
Review Attribute QuoteType Behavior vs InternalQuoteType fixes #552, #516

### DIFF
--- a/src/HtmlAgilityPack.Shared/HtmlAttribute.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlAttribute.cs
@@ -31,13 +31,13 @@ namespace HtmlAgilityPack
         internal int _namestartindex;
         internal HtmlDocument _ownerdocument; // attribute can exists without a node
         internal HtmlNode _ownernode;
-        private AttributeValueQuote _quoteType = AttributeValueQuote.DoubleQuote;
+        private AttributeValueQuote? _quoteType;
         internal int _streamposition;
         internal string _value;
         internal int _valuelength;
         internal int _valuestartindex; 
-        internal bool _isFromParse;
-        internal bool _hasEqual;
+        //internal bool _isFromParse;
+        //internal bool _hasEqual;
         private bool? _localUseOriginalName;
 
         #endregion
@@ -168,14 +168,14 @@ namespace HtmlAgilityPack
         /// </summary>
         public AttributeValueQuote QuoteType
         {
-            get { return _quoteType; }
-            set { _quoteType = value; }
+            get { return _quoteType ?? this.InternalQuoteType ?? this.OwnerDocument.GlobalAttributeValueQuote ?? AttributeValueQuote.DoubleQuote; }
+            set { _quoteType = value != AttributeValueQuote.Initial ? (AttributeValueQuote?)value : null; }
         }
 
         /// <summary>
         /// Specifies what type of quote the data should be wrapped in (internal to keep backward compatibility)
         /// </summary>
-        internal AttributeValueQuote InternalQuoteType { get; set; }
+        internal AttributeValueQuote? InternalQuoteType { get; set; }
 
         /// <summary>
         /// Gets the stream position of this attribute in the document, relative to the start of the document.
@@ -213,6 +213,10 @@ namespace HtmlAgilityPack
             set
             {
                 _value = value;
+                if (!string.IsNullOrEmpty(_value) && this.QuoteType == AttributeValueQuote.WithoutValue)
+                {
+                    this.InternalQuoteType = this.OwnerDocument.GlobalAttributeValueQuote ?? AttributeValueQuote.DoubleQuote;
+                }
 
                 if (_ownernode != null)
                 {
@@ -284,11 +288,11 @@ namespace HtmlAgilityPack
             HtmlAttribute att = new HtmlAttribute(_ownerdocument);
             att.Name = OriginalName;
             att.Value = Value;
-            att.QuoteType = QuoteType;
+            att._quoteType = _quoteType;
             att.InternalQuoteType = InternalQuoteType;
 
-            att._isFromParse = _isFromParse;
-            att._hasEqual = _hasEqual;
+            //att._isFromParse = _isFromParse;
+            //att._hasEqual = _hasEqual;
             return att;
         }
 

--- a/src/HtmlAgilityPack.Shared/HtmlDocument.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlDocument.cs
@@ -1503,7 +1503,7 @@ namespace HtmlAgilityPack
                         if (NewCheck())
                             continue;
 
-                        _currentattribute._isFromParse = true;
+                        //_currentattribute._isFromParse = true;
 
 
                         //  Add !,?,% and other special? 
@@ -1525,7 +1525,7 @@ namespace HtmlAgilityPack
                         if (_c == '=')
                         {
                             PushAttributeNameEnd(_index - 1);
-                            _currentattribute._hasEqual = true;
+                            //_currentattribute._hasEqual = true;
                             _state = ParseState.AttributeAfterEquals;
                             continue;
                         }
@@ -1573,7 +1573,7 @@ namespace HtmlAgilityPack
 
                         if (_c == '=')
                         {
-                            _currentattribute._hasEqual = true;
+                            //_currentattribute._hasEqual = true;
                             _state = ParseState.AttributeAfterEquals;
                             continue;
                         }
@@ -1822,6 +1822,7 @@ namespace HtmlAgilityPack
             _currentattribute.Line = _line;
             _currentattribute._lineposition = lineposition;
             _currentattribute._streamposition = index;
+            _currentattribute.InternalQuoteType = AttributeValueQuote.WithoutValue;
         }
 
         private void PushAttributeValueEnd(int index)
@@ -2044,11 +2045,13 @@ namespace HtmlAgilityPack
             _currentattribute._valuestartindex = index;
             if (quote == '\'')
             {
-                _currentattribute.QuoteType = AttributeValueQuote.SingleQuote;
+                _currentattribute.InternalQuoteType = AttributeValueQuote.SingleQuote;
+            }
+            if (quote == '"')
+            {
+                _currentattribute.InternalQuoteType = AttributeValueQuote.DoubleQuote;
             }
 
-            _currentattribute.InternalQuoteType = _currentattribute.QuoteType;
-            
             if (quote == 0)
             {
                 _currentattribute.InternalQuoteType = AttributeValueQuote.None;

--- a/src/HtmlAgilityPack.Shared/HtmlNode.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlNode.cs
@@ -2346,15 +2346,16 @@ namespace HtmlAgilityPack
 			}
 
 			var quoteType = OwnerDocument.GlobalAttributeValueQuote ?? att.QuoteType;
-			var isWithoutValue = quoteType == AttributeValueQuote.WithoutValue
-						 || (quoteType == AttributeValueQuote.Initial && att._isFromParse && !att._hasEqual && string.IsNullOrEmpty(att.XmlValue));
+			//var isWithoutValue = quoteType == AttributeValueQuote.WithoutValue
+			//			 || (quoteType == AttributeValueQuote.Initial && att._isFromParse && !att._hasEqual && string.IsNullOrEmpty(att.XmlValue));
 
-			if (quoteType == AttributeValueQuote.Initial && !(att._isFromParse && !att._hasEqual && string.IsNullOrEmpty(att.XmlValue)))
+			if (quoteType == AttributeValueQuote.Initial/* && !(att._isFromParse && !att._hasEqual && string.IsNullOrEmpty(att.XmlValue))*/)
 			{
-				quoteType = att.InternalQuoteType;
+				quoteType = att.QuoteType;
 			}
+			var isWithoutValue = quoteType == AttributeValueQuote.WithoutValue;
 
-			string name;
+            string name;
 			string quote = quoteType == AttributeValueQuote.DoubleQuote ? "\"" : quoteType == AttributeValueQuote.SingleQuote ? "'" : "";
             if (_ownerdocument.OptionOutputAsXml)
 			{

--- a/src/Tests/HtmlAgilityPack.Tests.Net45/HtmlDocument.PreserveOriginalTest.cs
+++ b/src/Tests/HtmlAgilityPack.Tests.Net45/HtmlDocument.PreserveOriginalTest.cs
@@ -1,9 +1,10 @@
 ﻿using NUnit.Framework;
 using System;
 using System.IO;
+using System.Linq;
 using System.Xml.XPath;
 
-namespace HtmlAgilityPack.Tests.fx._4._5
+namespace HtmlAgilityPack.Tests
 {
     [TestFixture]
     public class HtmlDocumentPreserveOriginalTest
@@ -167,6 +168,19 @@ namespace HtmlAgilityPack.Tests.fx._4._5
             var cloned = d.DocumentNode.CloneNode(true);
 
             Assert.AreEqual(@"<list-counter formErrorsCounter></list-counter>", cloned.OuterHtml);
+        }
+
+        [Test]
+        public void PreserveQuoteTypeForLoadedAttributes()
+        {
+            var input = HtmlNode.CreateNode("<input checked></input>");
+            var checkedAttribute = input.Attributes.First();
+
+            // Result is: Value: '' (empty string)
+            Assert.AreEqual("", checkedAttribute.Value);
+
+            // Result is: QuoteType: WithoutValue
+            Assert.AreEqual(AttributeValueQuote.WithoutValue, checkedAttribute.QuoteType);
         }
     }
 }

--- a/src/Tests/HtmlAgilityPack.Tests.Net45/UnitTest1.cs
+++ b/src/Tests/HtmlAgilityPack.Tests.Net45/UnitTest1.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace HtmlAgilityPack.Tests.fx._4._5
+namespace HtmlAgilityPack.Tests
 {
     [TestClass]
     public class UnitTest1

--- a/src/Tests/HtmlAgilityPack.Tests.Net45/files/attr_quote.html
+++ b/src/Tests/HtmlAgilityPack.Tests.Net45/files/attr_quote.html
@@ -1,4 +1,4 @@
-﻿ ﻿<form xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+﻿<form xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
     <page>
 
         <page-body>

--- a/src/Tests/HtmlAgilityPack.Tests.Net45/files/attr_quote_expected.html
+++ b/src/Tests/HtmlAgilityPack.Tests.Net45/files/attr_quote_expected.html
@@ -1,4 +1,4 @@
-﻿<form xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+<form xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
     <page>
 
         <page-body>
@@ -22,7 +22,7 @@
                                 {{ dimension.code }} - {{ dimension.description }}
                             </mat-option>
                         </mat-select>
-                        <span readOnlyValue> {{ simulationRequest.categoriaBemId | commonData:lea546CATBEM$:'id':'code-desc' }} </span>
+                        <span readOnlyValue>{{ simulationRequest.categoriaBemId | commonData:lea546CATBEM$:'id':'code-desc' }}</span>
                         <field-error-alert matSuffix></field-error-alert>
                         <mat-error></mat-error>
                     </mat-form-field>


### PR DESCRIPTION
Hi :),

I just faced an issue where adhoc created attributes where allways being quoted SingleQuote despite having QuoteType set to DoubleQuote as described in #552 
When looking at the code I realized some inconsistencies in the behavior of InternalQuoteType vs QuoteType.
As such here is my proposed behavior for these properties:
1) InternalQuoteType is the QuoteType inferred by the system when reading the document or on Value set ( ex: Value being set for atribute with WithoutValue )
2) QuoteType is the value set by the user that overrides the Internal calculated value, except if the value is being set to Initial wich rolls back the QuoteType to the internal value 

With this behavior I believe we can have a consistent and intuitive way of handling quotes in attributes
All public behavior of the classes was kept untouched so there should not be any breaking change ( ex: Global setting in the document still overrides any of these attributes )

Please consider this change since I believe it fixes #552 and #516 and makes attribute quoting much more intuitive.

Thanks and best regards
POFerro 