### PR TITLE
Add non-boxing enumerator for HtmlNodeCollection

### DIFF
--- a/src/HtmlAgilityPack.Shared/HtmlNodeCollection.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlNodeCollection.cs
@@ -172,6 +172,15 @@ namespace HtmlAgilityPack
         /// Get Enumerator
         /// </summary>
         /// <returns></returns>
+        public List<HtmlNode>.Enumerator GetEnumerator()
+        {
+            return _items.GetEnumerator();
+        }
+
+        /// <summary>
+        /// Get Enumerator
+        /// </summary>
+        /// <returns></returns>
         IEnumerator<HtmlNode> IEnumerable<HtmlNode>.GetEnumerator()
         {
             return _items.GetEnumerator();


### PR DESCRIPTION
When checking for docfx performance, I noticed that a lot of enumerator allocations were done inside of HtmlAgilityPack. This PR adds public struct enumerator access which won't need to box against interface, foreach loops will start to use this one.

![image](https://github.com/zzzprojects/html-agility-pack/assets/171892/d0538afa-9ca3-4ecb-b1d6-edb94ce61fb9)
