### PR TITLE
Don't allocate AttributesCollection in HtmlNode unless needed

### DIFF
--- a/src/HtmlAgilityPack.Shared/HtmlNode.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlNode.cs
@@ -254,20 +254,7 @@ namespace HtmlAgilityPack
 		/// </summary>
 		public bool HasAttributes
 		{
-			get
-			{
-				if (_attributes == null)
-				{
-					return false;
-				}
-
-				if (_attributes.Count <= 0)
-				{
-					return false;
-				}
-
-				return true;
-			}
+			get { return _attributes != null && _attributes.Count > 0; }
 		}
 
 		/// <summary>
@@ -1053,7 +1040,7 @@ namespace HtmlAgilityPack
 		/// <returns></returns>
 		public IEnumerable<HtmlAttribute> ChildAttributes(string name)
 		{
-			return Attributes.AttributesWithName(name);
+			return HasAttributes ? Attributes.AttributesWithName(name) : Enumerable.Empty<HtmlAttribute>();
 		}
 
 		/// <summary>
@@ -2402,7 +2389,7 @@ namespace HtmlAgilityPack
 
 		internal string GetId()
 		{
-			HtmlAttribute att = Attributes["id"];
+			HtmlAttribute att = HasAttributes ? Attributes["id"] : null;
 			return att == null ? string.Empty : att.Value;
 		}
 

--- a/src/HtmlAgilityPack.Shared/HtmlNodeNavigator.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlNodeNavigator.cs
@@ -539,7 +539,7 @@ namespace HtmlAgilityPack
 #if TRACE_NAVIGATOR
             InternalTrace("localName=" + localName + ", namespaceURI=" + namespaceURI);
 #endif
-			HtmlAttribute att = _currentnode.Attributes[localName];
+			HtmlAttribute att = _currentnode.HasAttributes ? _currentnode.Attributes[localName] : null;
 			if (att == null)
 			{
 #if TRACE_NAVIGATOR


### PR DESCRIPTION
Calling `HtmlNode.GetId` and others can cause attribute collection construction, changing to check whether there are attributes before accessing the allocating `Attributes` getter.