### PR TITLE
Add tfoot to appropriate fields in IsParentExplicitEnd

### DIFF
--- a/src/HtmlAgilityPack.Shared/HtmlDocument.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlDocument.cs
@@ -1956,19 +1956,19 @@ namespace HtmlAgilityPack
                     isExplicitEnd = nodeName == "table";
                     break;
                 case "tr":
-                    isExplicitEnd = nodeName == "tr" || nodeName == "tbody";
+                    isExplicitEnd = nodeName == "tr" || nodeName == "thead" || nodeName == "tbody" || nodeName == "tfoot";
                     break;
                 case "thead":
-                    isExplicitEnd = nodeName == "tbody";
+                    isExplicitEnd = nodeName == "tbody" || nodeName == "tfoot";
                     break;
                 case "tbody":
-                    isExplicitEnd = nodeName == "tbody";
+                    isExplicitEnd = nodeName == "tbody" || nodeName == "tfoot";
                     break;
                 case "td":
-                    isExplicitEnd = nodeName == "td" || nodeName == "th" || nodeName == "tr" || nodeName == "tbody";
+                    isExplicitEnd = nodeName == "td" || nodeName == "th" || nodeName == "tr" || nodeName == "tbody" || nodeName == "tfoot";
                     break;
                 case "th":
-                    isExplicitEnd = nodeName == "td" || nodeName == "th" || nodeName == "tr" || nodeName == "tbody";
+                    isExplicitEnd = nodeName == "td" || nodeName == "th" || nodeName == "tr" || nodeName == "tbody" || nodeName == "tfoot";
                     break;
                 case "h1":
                     isExplicitEnd = nodeName == "h2" || nodeName == "h3" || nodeName == "h4" || nodeName == "h5";


### PR DESCRIPTION
fixes #562

Added tfoot to IsParentExplicitEnd, based on my reading of the MDN docs stating when the affected end tags are optional.

I'm not able to run all test cases (I think I'm missing some of the supported platforms), but a quick test program shows that it fixes my example code.