### PR TITLE
Global quote type = Initial should not override attribute quote type on value set

### DIFF
--- a/src/HtmlAgilityPack.Shared/HtmlAttribute.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlAttribute.cs
@@ -213,7 +213,9 @@ namespace HtmlAgilityPack
                 _value = value;
                 if (!string.IsNullOrEmpty(_value) && this.QuoteType == AttributeValueQuote.WithoutValue)
                 {
-                    this.InternalQuoteType = this.OwnerDocument.GlobalAttributeValueQuote ?? AttributeValueQuote.DoubleQuote;
+                    this.InternalQuoteType = this.OwnerDocument.GlobalAttributeValueQuote != AttributeValueQuote.Initial ?
+                        (this.OwnerDocument.GlobalAttributeValueQuote ?? AttributeValueQuote.DoubleQuote)
+                        : AttributeValueQuote.DoubleQuote;
                 }
 
                 if (_ownernode != null)

--- a/src/Tests/HtmlAgilityPack.Tests.NetStandard2_0/HtmlAgilityPack.Tests.NetStandard2_0.csproj
+++ b/src/Tests/HtmlAgilityPack.Tests.NetStandard2_0/HtmlAgilityPack.Tests.NetStandard2_0.csproj
@@ -7,6 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="files\*" />
+    <Content Include="files\*">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />

--- a/src/Tests/HtmlAgilityPack.Tests.NetStandard2_0/HtmlDocument.PreserveOriginalTest.cs
+++ b/src/Tests/HtmlAgilityPack.Tests.NetStandard2_0/HtmlDocument.PreserveOriginalTest.cs
@@ -1,0 +1,177 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Xml.XPath;
+using Xunit;
+
+namespace HtmlAgilityPack.Tests.NetStandard2_0
+{
+    public class HtmlDocumentPreserveOriginalTest
+    {
+        [Fact]
+        public void PreserveEmptyAttributesTest()
+        {
+            var d = new HtmlDocument();
+            d.OptionEmptyCollection = true;
+
+            d.GlobalAttributeValueQuote = AttributeValueQuote.Initial;
+
+            d.OptionDefaultUseOriginalName = true;
+            //d.OptionPreserveEmptyAttributes = true;
+
+            var html = @"
+<form #editForm='ngForm' (ngSubmit)='OnSaveData()' name='globalForm' [dataSourceContext]='detailDataSourceContext'>
+  <page editable (beginEdit)='OnBeginEdit()' (cancelEdit)='OnCancelEdit($event)'>
+
+  <page-header pageHeaderIcon='_Lea_ mdi mdi-code-json'>
+
+    <page-header-actions>
+      <list-counter formErrorsCounter></list-counter>
+
+      <button mat-button *hasEveryPermission='permissionConstants.LeaProdutos.edit' enterEditButton>
+      </button>
+
+      <button mat-button *hasEveryPermission='permissionConstants.LeaProdutos.edit' cancelEditButton>
+      </button>
+
+      <button mat-button *hasEveryPermission='permissionConstants.LeaProdutos.edit' type='submit' confirmEditButton>
+      </button>
+
+      <refresh-button></refresh-button>
+    </page-header-actions>
+
+  </page-header>
+
+    <page-body>
+    </page-body>
+
+  </page>
+</form>
+";
+            d.LoadHtml(html);
+
+            var outer = d.DocumentNode.OuterHtml;
+
+            var xpath = XPathExpression.Compile("/form/page/page-header/page-header-actions/button[@enterEditButton]");
+            var nodes = d.DocumentNode.SelectNodes(xpath);
+
+            Assert.Equal(1, nodes?.Count);
+            Assert.Equal(html, d.DocumentNode.OuterHtml);
+        }
+
+        [Fact]
+        public void PreserveOriginalCasingTest()
+        {
+            var d = new HtmlDocument();
+            d.OptionEmptyCollection = true;
+
+            d.GlobalAttributeValueQuote = AttributeValueQuote.Initial;
+
+            d.OptionDefaultUseOriginalName = true;
+            //d.OptionPreserveEmptyAttributes = true;
+
+            var html = @"
+<form #editForm='ngForm' (ngSubmit)='OnSaveData()' name='globalForm' [dataSourceContext]='detailDataSourceContext'>
+  <page editable (beginEdit)='OnBeginEdit()' (cancelEdit)='OnCancelEdit($event)'>
+
+  <page-Header pageHeaderIcon='_Lea_ mdi mdi-code-json'>
+
+    <page-Header-Actions>
+      <list-counter formErrorsCounter></list-counter>
+
+      <button mat-button *hasEveryPermission='permissionConstants.LeaProdutos.edit' enterEditButton>
+      </button>
+
+      <button mat-button *hasEveryPermission='permissionConstants.LeaProdutos.edit' cancelEditButton>
+      </button>
+
+      <button mat-button *hasEveryPermission='permissionConstants.LeaProdutos.edit' type='submit' confirmEditButton>
+      </button>
+
+      <refresh-button></refresh-button>
+    </page-Header-Actions>
+
+  </page-Header>
+
+    <page-body>
+    </page-body>
+
+  </page>
+</form>
+";
+            d.LoadHtml(html);
+
+            var xpath = XPathExpression.Compile("/form/page/page-Header/page-Header-Actions/button[@enterEditButton]");
+            var nodes = d.DocumentNode.SelectNodes(xpath);
+
+            Assert.Equal(1, nodes?.Count);
+            Assert.Equal(html, d.DocumentNode.OuterHtml);
+        }
+
+
+        [Fact]
+        public void PreserveOriginalQuoteTest()
+        {
+            var contentDirectory = Path.GetDirectoryName(typeof(HtmlDocumentPreserveOriginalTest).Assembly.Location).ToString() + "\\files\\";
+
+            var d = new HtmlDocument();
+            d.OptionEmptyCollection = true;
+
+            d.GlobalAttributeValueQuote = AttributeValueQuote.Initial;
+            d.OptionDefaultUseOriginalName = true;
+
+            var filePath = Path.Combine(contentDirectory, "attr_quote.html");
+            var filePathExpected = Path.Combine(contentDirectory, "attr_quote_expected.html");
+            d.Load(filePath);
+
+            var xpath = XPathExpression.Compile("/form/page/page-body/card/data-group/mat-form-field[@*[local-name() = 'xdt:Transform' and . = \"InsertAfter(mat-form-field[mat-select/@name = 'tipoProdutoId'])\"]]/mat-select/mat-option");
+            var nodes = d.DocumentNode.SelectNodes(xpath);
+
+            Assert.Equal(1, nodes?.Count);
+
+            nodes[0].ParentNode.Attributes["required"].Value = "true";
+
+            Assert.Equal(File.ReadAllText(filePathExpected), d.DocumentNode.OuterHtml);
+
+            var clone = nodes[0].CloneNode(true);
+
+            var expectedOuterNode = @"<mat-option *ngFor=""let dimension of lea546CATBEM$  | async | filterDimensionByValue:( simulationRequest.tipoProdutoId |  commonData:lea508SUBPROD$:'id':'code')"" [value]=""dimension.dimensionId"">
+
+
+                                {{ dimension.code }} - {{ dimension.description }}
+                            </mat-option>";
+
+            Assert.Equal(expectedOuterNode, clone.OuterHtml);
+
+        }
+
+
+        [Fact]
+        public void PreserveClonedEmptyAttributesTest()
+        {
+            var d = new HtmlDocument();
+            d.GlobalAttributeValueQuote = AttributeValueQuote.Initial;
+            d.OptionDefaultUseOriginalName = true;
+
+            var html = @"<list-counter formErrorsCounter></list-counter>";
+            d.LoadHtml(html);
+
+            var cloned = d.DocumentNode.CloneNode(true);
+
+            Assert.Equal(@"<list-counter formErrorsCounter></list-counter>", cloned.OuterHtml);
+        }
+
+        [Fact]
+        public void PreserveQuoteTypeForLoadedAttributes()
+        {
+            var input = HtmlNode.CreateNode("<input checked></input>");
+            var checkedAttribute = input.Attributes.First();
+
+            // Result is: Value: '' (empty string)
+            Assert.Equal("", checkedAttribute.Value);
+
+            // Result is: QuoteType: WithoutValue
+            Assert.Equal(AttributeValueQuote.WithoutValue, checkedAttribute.QuoteType);
+        }
+    }
+}

--- a/src/Tests/HtmlAgilityPack.Tests.NetStandard2_0/files/attr_quote.html
+++ b/src/Tests/HtmlAgilityPack.Tests.NetStandard2_0/files/attr_quote.html
@@ -1,0 +1,47 @@
+﻿<form xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+    <page>
+
+        <page-body>
+            <form #simulatorForm="ngForm" xdt:Transform="InsertBefore(/form/page/page-body/card[1])"
+                  fxFlex="50%" fxFlex.lt-md="100%"
+                  [dataSourceContext]="simulatorDataSourceContext" name="simulatorForm">
+                <ng-container></ng-container>
+            </form>
+            <!--DADOS DE SIMULAÇÃO-->
+            <card xdt:Transform="SetAttributes(*)"
+                  xdt:Locator="Condition(card-header/card-header-title-container/card-header-title = &quot;{{ 'Lea.Cotacoes.Cards.Dados de Simulação' | translate }}&quot;)"
+                  editable
+                  fxFlex="100%">
+                <data-group>
+
+                    <!-- INSERT CategoriaBem AFTER mat-form-field with mat-select@name = 'tipoProdutoId' -->
+                    <mat-form-field xdt:Transform="InsertAfter(mat-form-field[mat-select/@name = 'tipoProdutoId'])"
+                                    fxFlex="50%" fxFlex.lt-md="50%" fxFlex.lt-sm="100%" *ngIf="!!simulationRequest.tipoProdutoId">
+                        <!-- CategoriaBem -->
+                        <mat-label>
+                            <span>{{ 'Lea.Cotacoes.Simulador.CodCategoriaBem' | translate}}</span>
+                        </mat-label>
+                        <mat-select name="codCategoriaBemId" required
+                                    (selectionChange)="GetProductDetails()"
+                                    [(ngModel)]="simulationRequest.categoriaBemId">
+                            <mat-option *ngFor="let dimension of lea546CATBEM$  | async | filterDimensionByValue:( simulationRequest.tipoProdutoId |  commonData:lea508SUBPROD$:'id':'code')" [value]="dimension.dimensionId">
+
+
+                                {{ dimension.code }} - {{ dimension.description }}
+                            </mat-option>
+                        </mat-select>
+                        <span readOnlyValue>{{ simulationRequest.categoriaBemId | commonData:lea546CATBEM$:'id':'code-desc' }}</span>
+                        <field-error-alert matSuffix></field-error-alert>
+                        <mat-error></mat-error>
+                    </mat-form-field>
+
+                </data-group>
+
+            </card>
+
+
+        </page-body>
+
+
+    </page>
+</form>

--- a/src/Tests/HtmlAgilityPack.Tests.NetStandard2_0/files/attr_quote_expected.html
+++ b/src/Tests/HtmlAgilityPack.Tests.NetStandard2_0/files/attr_quote_expected.html
@@ -1,0 +1,39 @@
+<form xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+    <page>
+
+        <page-body>
+            <form #simulatorForm="ngForm" xdt:Transform="InsertBefore(/form/page/page-body/card[1])" fxFlex="50%" fxFlex.lt-md="100%" [dataSourceContext]="simulatorDataSourceContext" name="simulatorForm">
+                <ng-container></ng-container>
+            </form>
+            <!--DADOS DE SIMULAÇÃO-->
+            <card xdt:Transform="SetAttributes(*)" xdt:Locator="Condition(card-header/card-header-title-container/card-header-title = &quot;{{ 'Lea.Cotacoes.Cards.Dados de Simulação' | translate }}&quot;)" editable fxFlex="100%">
+                <data-group>
+
+                    <!-- INSERT CategoriaBem AFTER mat-form-field with mat-select@name = 'tipoProdutoId' -->
+                    <mat-form-field xdt:Transform="InsertAfter(mat-form-field[mat-select/@name = 'tipoProdutoId'])" fxFlex="50%" fxFlex.lt-md="50%" fxFlex.lt-sm="100%" *ngIf="!!simulationRequest.tipoProdutoId">
+                        <!-- CategoriaBem -->
+                        <mat-label>
+                            <span>{{ 'Lea.Cotacoes.Simulador.CodCategoriaBem' | translate}}</span>
+                        </mat-label>
+                        <mat-select name="codCategoriaBemId" required="true" (selectionChange)="GetProductDetails()" [(ngModel)]="simulationRequest.categoriaBemId">
+                            <mat-option *ngFor="let dimension of lea546CATBEM$  | async | filterDimensionByValue:( simulationRequest.tipoProdutoId |  commonData:lea508SUBPROD$:'id':'code')" [value]="dimension.dimensionId">
+
+
+                                {{ dimension.code }} - {{ dimension.description }}
+                            </mat-option>
+                        </mat-select>
+                        <span readOnlyValue>{{ simulationRequest.categoriaBemId | commonData:lea546CATBEM$:'id':'code-desc' }}</span>
+                        <field-error-alert matSuffix></field-error-alert>
+                        <mat-error></mat-error>
+                    </mat-form-field>
+
+                </data-group>
+
+            </card>
+
+
+        </page-body>
+
+
+    </page>
+</form>


### PR DESCRIPTION
Hi @JonathanMagnan :)

This PR solves an error where an initially loaded attribute without quote gets a quote type of Initial even when value is set, this causes the attribute to be written without quotes even having a value.

Also added some test cases for these occasions :)

Thanks and best regards