### PR TITLE
Make LoadFromWebAsync honor the Timeout property. Fixes #580

### DIFF
--- a/src/HtmlAgilityPack.Shared/HtmlWeb.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlWeb.cs
@@ -2431,6 +2431,8 @@ namespace HtmlAgilityPack
                 client = GetSharedHttpClient(this.UserAgent);
             }
 
+            client.Timeout = TimeSpan.FromMilliseconds(Timeout);
+
 			var e = await client.GetAsync(uri, cancellationToken).ConfigureAwait(false);
             _statusCode = e.StatusCode;
 
@@ -2442,7 +2444,7 @@ namespace HtmlAgilityPack
                 }
                 else
                 {
-#if !(NETSTANDARD1_3 || NETSTANDARD1_6 || WINDOWS_UWP) 
+#if !(NETSTANDARD1_3 || NETSTANDARD1_6 || WINDOWS_UWP)
                     _responseUri = new Uri(uri.GetLeftPart(UriPartial.Authority) + e.Headers.Location);
 #endif
                 }


### PR DESCRIPTION
While I was testing out the library's `LoadFromWebAsync` methods, I noticed that the `Timeout` property is not registered for the used `HttpClient` instance. 

I was always thrown a `TaskCanceledException` with the [default Microsoft set 100 seconds timeout](https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpclient.timeout?view=net-9.0#remarks), I could not even influence it via providing a custom `PreRequest` delegate.

I checked the active issues and I saw someone else also encountered this behavior. #580