### PR TITLE
IsOverlappedClosingElement: Incorrect Length Check for Minimal Tags

### DIFF
--- a/src/HtmlAgilityPack.Shared/HtmlNode.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlNode.cs
@@ -913,7 +913,7 @@ namespace HtmlAgilityPack
 			}
 
 			// min is </x>: 4
-			if (text.Length <= 4)
+			if (text.Length < 4)
 				return false;
 
 			if ((text[0] != '<') ||


### PR DESCRIPTION
The current implementation includes the following check:

```csharp
if (text.Length <= 4)
    return false;
```
This condition inadvertently excludes valid minimal closing tags like </b> or </i>, which have a length of exactly 4 characters. To accurately assess such tags, the condition should be adjusted to:

```csharp
if (text.Length < 4)
    return false;
```
This change ensures that tags with a length of 4 are properly evaluated.

```csharp
HtmlNode.IsOverlappedClosingElement("</b>"); // Returns false, but should return true
```